### PR TITLE
Fix various issues with the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+This repository hosts the [whatwg.org](https://whatwg.org/) and
+[spec.whatwg.org](https://spec.whatwg.org/) sites. Feel free to help improve them!
+
+### Code of conduct
+
+We are committed to providing a friendly, safe and welcoming environment for all. Please read and
+respect the [WHATWG Code of Conduct](https://wiki.whatwg.org/wiki/Code_of_Conduct).

--- a/src/.htaccess
+++ b/src/.htaccess
@@ -92,6 +92,8 @@ redirect permanent /mailing-list) https://whatwg.org/mailing-list
 redirect permanent /google2569a0eb653e4cf1.html https://whatwg.org/
 redirect permanent /link-fixup.js https://html.spec.whatwg.org/multipage/link-fixup.js
 
+RedirectMatch 301 ^/specs/?$ https://spec.whatwg.org/
+
 # set up the translated files to be HTML
 <files *.pl>
    ForceType text/html

--- a/src/404
+++ b/src/404
@@ -1,12 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<!doctype html>
 <html>
  <head>
   <title>Web Hypertext Application Technology Working Group: File Not Found</title>
-  <link rel="stylesheet" media="all" href="/style/tabbed-pages">
+  <link rel="stylesheet" href="/style/tabbed-pages">
   <link rel="icon" href="/images/icon">
-  <style type="text/css">
-   img { float: right; margin: 0 0 1em 1em; }
-  </style>
  </head>
  <body>
   <h1>
@@ -19,15 +16,13 @@
    <li><a href="/news/">News</a></li>
    <li><a href="/demos/">Demos</a></li>
    <li><a href="/specs/">Specifications</a></li>
-   <li><a href="/charter">Charter</a></li>
    <li><a href="/mailing-list">Mailing List</a></li>
   </ul>
   <h2>File Not Found</h2>
   <p>The file you are looking for could not be found.</p>
-  <!--multipage-->
   <p>If you have found a broken link on the WHATWG site itself, please
-  e-mail <a href="mailto:ian@hixie.ch">Ian Hickson</a>. If you found a
-  broken link from another site pointing to the WHATWG site, please
-  let that site know of the problem instead. Thanks!</p>
+  <a href="https://github.com/whatwg/whatwg.org/issues/new">file an issue</a>. If you found a broken
+  link from another site pointing to the WHATWG site, please let that site know of the problem
+  instead. Thanks!</p>
  </body>
 </html>

--- a/src/charter
+++ b/src/charter
@@ -200,9 +200,10 @@
    <li id="mjs">Maciej Stachowiak</li>
   </ul>
 
-  <address id="ian">Queries should be directed either to the mailing
-  list or to <a href="mailto:ian@hixie.ch">Ian Hickson</a>, who is
-  acting as a spokesman for the group.</address>
+  <address id="ian">Queries can be directed either as a
+  <a href="https://github.com/whatwg/meta/issues/new">new meta issue</a> or as an email to
+  <a href="mailto:ian+whatwg@hixie.ch">Ian Hickson</a>, who is acting as a spokesperson for the
+  WHATWG.</address>
 
  </body>
 </html>

--- a/src/index
+++ b/src/index
@@ -32,10 +32,10 @@
   <a href="https://whatwg.org/specs/"><p><strong>Spec Index</strong> <span>See the list of our other</span> <span>Web technology specifications</span></p></a>
 -->
 
-  <address>Queries should be directed either to one of our <a
-  href="/mailing-list">mailing list</a> or to <a
-  href="mailto:ian+whatwg@hixie.ch">Ian Hickson</a>, who is acting as
-  a spokesman for the group.</address>
+  <address>Queries can be directed either as a
+  <a href="https://github.com/whatwg/meta/issues/new">new meta issue</a> or as an email to
+  <a href="mailto:ian+whatwg@hixie.ch">Ian Hickson</a>, who is acting as a spokesperson for the
+  WHATWG.</address>
 
   <script> var _gaq = [['_setAccount', 'UA-20955470-1'], ['_setDomainName', '.whatwg.org'], ['_trackPageview']]; </script>
   <script async src="https://ssl.google-analytics.com/ga.js"></script>

--- a/src/specs/index
+++ b/src/specs/index
@@ -1,10 +1,10 @@
 <!DOCTYPE HTML>
+<!-- Note: this resource is served from https://spec.whatwg.org/ -->
 <html>
  <head>
-  <base href="https://whatwg.org/specs/"> <!-- because it's also used on https://spec.whatwg.org/ -->
-  <title>Web Hypertext Application Technology Working Group Specifications</title>
-  <link rel="stylesheet" media="all" href="/style/tabbed-pages">
-  <link rel="icon" href="/images/icon">
+  <title>Web Hypertext Application Technology Working Group Standards</title>
+  <link rel="stylesheet" href="https://whatwg.org/style/tabbed-pages">
+  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
  </head>
  <body>
   <h1>
@@ -13,29 +13,21 @@
    <span class="wg">Working Group</span>
   </h1>
   <ul class="navigation">
-   <li><a href="/" rel="home">Home</a></li>
-   <li><a href="/demos/">Demos</a></li>
-   <li class="this"><strong>Specifications</strong></li>
-   <li><a href="/mailing-list">Mailing List</a></li>
+   <li><a href="https://whatwg.org/" rel="home">Home</a></li>
+   <li class="this"><strong>Standards</strong></li>
   </ul>
 
-  <p>The WHATWG works on a number of technologies that widely get
-  referred to by the buzzword "<a
-  href="https://html.spec.whatwg.org/multipage/introduction.html#is-this-html5?">HTML5</a>".
-  They are organised somewhat arbitrarily based on the preferences of
-  those editing the specifications for those technologies.</p>
+  <p>The WHATWG works on a number of technologies that are fundamental parts of the web platform.
+  They are organised somewhat arbitrarily based on the preferences of those editing the standard for
+  those technologies.</p>
 
   <dl>
 
    <dt><a href="https://html.spec.whatwg.org/multipage/">HTML</a></dt>
    <dd>
-    <p>This specification is a kitchen sink full of technologies for
-    the Web. It includes the core markup language for the Web, HTML,
-    as well as numerous APIs like Web Sockets, Web Workers, Web
-    Storage, etc.</p>
-    <p>We also provide <strong><a
-    href="https://developers.whatwg.org/">an edition of HTML optimized
-    for Web developers</a></strong>.</p>
+    <p>The HTML Standard is a kitchen sink full of technologies for
+    the web. It includes the core markup language for the web, HTML,
+    as well as numerous APIs like Web Sockets, Web Workers, <code>localStorage</code>, etc.</p>
    </dd>
 
    <dt><a href="https://infra.spec.whatwg.org/">Infra</a></dt>
@@ -46,63 +38,57 @@
 
    <dt><a href="https://dom.spec.whatwg.org/">DOM</a></dt>
    <dd>
-    <p>This specification defines the core infrastructure used to
-    define the Web.</p>
+    <p>The DOM Standard defines the core infrastructure used to define the web.</p>
    </dd>
 
    <dt><a href="https://fullscreen.spec.whatwg.org/">Fullscreen</a></dt>
    <dd>
-    <p>This specification defines how Web pages can take over a user's
+    <p>The Fullscreen API Standard defines how web pages can take over a user's
     entire screen (at the user's request), e.g. for gaming or to watch
     a video.</p>
    </dd>
 
    <dt><a href="https://notifications.spec.whatwg.org/">Notifications</a></dt>
    <dd>
-    <p>This specification provides an API to display notifications to
+    <p>The Notifications API Standard provides an API to display notifications to
     alert users outside the context of a web page.</p>
    </dd>
 
    <dt><a href="https://encoding.spec.whatwg.org/">Encoding</a></dt>
    <dd>
-    <p>This specification defines how character encodings work on the
-    Web.</p>
+    <p>The Encoding Standard defines how character encodings work on the web.</p>
    </dd>
 
-   <dt><a href="https://url.spec.whatwg.org/">URLs</a></dt>
+   <dt><a href="https://url.spec.whatwg.org/">URL</a></dt>
    <dd>
-    <p>This specification defines the infrastructure around URLs on
-    the Web.</p>
+    <p>The URL Standard defines the infrastructure around URLs on the web.</p>
    </dd>
 
    <dt><a href="https://fetch.spec.whatwg.org/">Fetch</a></dt>
    <dd>
-    <p>This specification defines the networking model for resource
-    retrieval on the Web.</p>
+    <p>The Fetch Standard defines the networking model for resource retrieval on the web.</p>
    </dd>
 
    <dt><a href="https://mimesniff.spec.whatwg.org/">MIME Sniffing</a></dt>
    <dd>
-    <p>This specification defines algorithms used to determine the
-    type of resources.</p>
+    <p>The MIME Sniffing Standard defines algorithms used to determine the type of resources.</p>
    </dd>
 
    <dt><a href="https://xhr.spec.whatwg.org/">XMLHttpRequest</a></dt>
    <dd>
-    <p>This specification defines the networking API exposed to
-    scripts on the Web.</p>
+    <p>The XMLHttpRequest Standard defines the networking API exposed to scripts on the web.</p>
    </dd>
 
    <dt><a href="https://compat.spec.whatwg.org/">Compatibility</a></dt>
    <dd>
-    <p>This standard describes a collection of non-standard (and often
+    <p>The Compatibility Standard describes a collection of non-standard (and often
     vendor-prefixed) CSS properties and DOM APIs that web browsers
     need to support for compatibility with the de facto web.</p>
    </dd>
 
    <dt><a href="https://console.spec.whatwg.org/">Console</a></dt>
    <dd>
-    <p>This specification defines APIs for console debugging facilities.</p>
+    <p>The Console Standard defines APIs for console debugging facilities.</p>
    </dd>
 
    <dt><a href="https://storage.spec.whatwg.org/">Storage</a></dt>
@@ -113,7 +99,7 @@
 
    <dt><a href="https://streams.spec.whatwg.org/">Streams</a></dt>
    <dd>
-    <p>This specification provides APIs for creating, composing, and
+    <p>The Streams Standard provides APIs for creating, composing, and
     consuming streams of data. These streams are designed to map
     efficiently to low-level I/O primitives, and allow easy
     composition with built-in backpressure and queuing. On top of
@@ -125,17 +111,18 @@
 
    <dt><a href="https://books.spec.whatwg.org/">Books</a></dt>
    <dd>
-    <p>This specification defines CSS features for book publishing and high-quality printing of Web pages.</p>
+    <p>The Books Standard defines CSS features for book publishing and high-quality printing of web
+    pages.</p>
    </dd>
 
    <dt><a href="https://figures.spec.whatwg.org/">Figures</a></dt>
    <dd>
-    <p>This specification defines CSS features for floating elements around pages and columns.</p>
+    <p>The Figures Standard defines CSS features for floating elements around pages and columns.</p>
    </dd>
 
    <dt><a href="https://quirks.spec.whatwg.org/">Quirks Mode</a></dt>
    <dd>
-    <p>This specification describes behaviours in CSS and Selectors
+    <p>The Quirks Mode Standard describes behaviours in CSS and Selectors
     that are not yet defined in the relevant specifications but that
     are nonetheless widely implemented.</p>
    </dd>


### PR DESCRIPTION
* Fixes #11 by adding a README.
* Fixes #14 by redirecting /specs/ to spec.whatwg.org.
* Fixes #15 by using spokesperson and removing the mention of HTML5.
* Fixes #13 by redirecting to whatwg/meta for queries.
* Addresses #9 partly by removing one reference to HTML for developers.
* Fixes #3 by mentioning this repository as the source of (potential)
trouble.