### PR TITLE
Replace reference to developers.whatwg.org with blog.whatwg.org

### DIFF
--- a/src/404
+++ b/src/404
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
  <head>
   <title>Web Hypertext Application Technology Working Group: File Not Found</title>
   <link rel="stylesheet" href="/style/tabbed-pages">

--- a/src/404
+++ b/src/404
@@ -3,7 +3,7 @@
  <head>
   <title>Web Hypertext Application Technology Working Group: File Not Found</title>
   <link rel="stylesheet" href="/style/tabbed-pages">
-  <link rel="icon" href="/images/icon">
+  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
  </head>
  <body>
   <h1>
@@ -15,7 +15,7 @@
    <li><a href="/" rel="home">Home</a></li>
    <li><a href="/news/">News</a></li>
    <li><a href="/demos/">Demos</a></li>
-   <li><a href="/specs/">Specifications</a></li>
+   <li><a href="https://spec.whatwg.org/">Standards</a></li>
    <li><a href="/mailing-list">Mailing List</a></li>
   </ul>
   <h2>File Not Found</h2>

--- a/src/charter
+++ b/src/charter
@@ -1,9 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
-<html>
+<!doctype html>
+<html lang="en">
  <head>
   <title>Web Hypertext Application Technology Working Group Charter</title>
-  <link rel="stylesheet" media="all" href="/style/tabbed-pages">
-  <link rel="icon" href="/images/icon">
+  <link rel="stylesheet" href="/style/tabbed-pages">
+  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
  </head>
  <body>
   <h1>
@@ -13,9 +13,7 @@
   </h1>
   <ul class="navigation">
    <li><a href="/" rel="home">Home</a></li>
-   <li><a href="/demos/">Demos</a></li>
-   <li><a href="/specs/">Specifications</a></li>
-   <li><a href="/mailing-list">Mailing List</a></li>
+   <li><a href="https://spec.whatwg.org/">Standards</a></li>
    <li class="this"><strong>Charter</strong></li>
   </ul>
 

--- a/src/index
+++ b/src/index
@@ -3,20 +3,20 @@
  <head>
   <title>Web Hypertext Application Technology Working Group</title>
   <link rel="stylesheet" href="/style/tabbed-pages">
-  <link rel="icon" href="/images/icon">
+  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
  </head>
  <body class="front-page">
   <hgroup>
-   <h1><object data="https://images.whatwg.org/logo.svg" height=101 width=101><img src="https://images.whatwg.org/logo" alt="" height=101 width=101></object> Welcome to the WHATWG community</h1>
+   <h1><img src="https://resources.whatwg.org/logo.svg" height=101 width=101 alt> Welcome to the WHATWG community</h1>
    <h2>Maintaining and evolving HTML since 2004</h2>
   </hgroup>
 
   <a href="https://wiki.whatwg.org/wiki/FAQ"><p><strong>FAQ</strong> <span>Get answers</span> <span>to your questions</span> <span>about HTML</span> <span>and the WHATWG</span></p></a>
   <a href="https://html.spec.whatwg.org/multipage/"><p><strong>HTML</strong> <span>Read, use,</span> <span>or implement</span> <span>the HTML Living Standard</span></p></a>
-  <a href="https://whatwg.org/specs/"><p><strong>Specs</strong> <span>See the other</span> specifications <span>developed at the WHATWG</span></p></a>
+  <a href="https://whatwg.org/specs/"><p><strong>Standards</strong> <span>See the other</span> standards <span>developed at the WHATWG</span></p></a>
 
-  <a href="https://developers.whatwg.org/"><p><strong>Web Dev Edition</strong> <span>Read an edition of</span> <span>the HTML standard</span> <span>designed for</span> <span>Web Developers</span></p></a>
-  <a href="http://html5.validator.nu/"><p><strong>Validator</strong> <span>Check your documents</span> <span>with an HTML validator</span></p></a>
+  <a href="https://blog.whatwg.org/"><p><strong>News</strong> <span>Read and contribute</span> <span>to the WHATWG blog</span></p></a>
+  <a href="https://checker.html5.org/"><p><strong>Html Checker</strong> <span>Validate your documents</span> <span>with an HTML checker</span></p></a>
   <a href="https://whatwg.org/mailing-list#help"><p><strong>Help</strong> <span>Send questions</span> and <span>help others</span> <span>in the <b>help@whatwg.org</b></span> <span>mailing list</span></p></a>
 
   <a href="https://whatwg.org/mailing-list"><p><strong>Join</strong> <span>Comment on</span> <span>our Web standards</span> <span>and send proposals</span> <span>of your own</span></p></a>
@@ -26,10 +26,8 @@
 <!--
   <a href="https://wiki.whatwg.org/"><p><strong>Wiki</strong> <span>Poke at our wiki pages</span> <span>and see what you unearth</span></p></a>
   <a href="https://forums.whatwg.org/"><p><strong>Forums</strong> <span>Talk with Web designers</span> <span>about how to write HTML</span></p></a>
-  <a href="https://blog.whatwg.org/"><p><strong>News</strong> <span>Read and contribute</span> <span>to the WHATWG blog</span></p></a>
   <a href="https://whatwg.org/demos/"><p><strong>Demos</strong> <span>Play with some simple HTML demos</span> <span>or get inspiration from our sample sites</span></p></a>
   <a href="https://twitter.com/WHATWG"><p><strong>Twitter</strong> <span>Keep track of spec changes</span> <span>by following our Twitter feed</span></p></a>
-  <a href="https://whatwg.org/specs/"><p><strong>Spec Index</strong> <span>See the list of our other</span> <span>Web technology specifications</span></p></a>
 -->
 
   <address>Queries can be directed either as a

--- a/src/index
+++ b/src/index
@@ -13,7 +13,7 @@
 
   <a href="https://wiki.whatwg.org/wiki/FAQ"><p><strong>FAQ</strong> <span>Get answers</span> <span>to your questions</span> <span>about HTML</span> <span>and the WHATWG</span></p></a>
   <a href="https://html.spec.whatwg.org/multipage/"><p><strong>HTML</strong> <span>Read, use,</span> <span>or implement</span> <span>the HTML Living Standard</span></p></a>
-  <a href="https://whatwg.org/specs/"><p><strong>Standards</strong> <span>See the other</span> standards <span>developed at the WHATWG</span></p></a>
+  <a href="https://spec.whatwg.org/"><p><strong>Standards</strong> <span>See the other</span> standards <span>developed at the WHATWG</span></p></a>
 
   <a href="https://blog.whatwg.org/"><p><strong>News</strong> <span>Read and contribute</span> <span>to the WHATWG blog</span></p></a>
   <a href="https://checker.html5.org/"><p><strong>Html Checker</strong> <span>Validate your documents</span> <span>with an HTML checker</span></p></a>

--- a/src/index
+++ b/src/index
@@ -16,7 +16,7 @@
   <a href="https://spec.whatwg.org/"><p><strong>Standards</strong> <span>See the other</span> standards <span>developed at the WHATWG</span></p></a>
 
   <a href="https://blog.whatwg.org/"><p><strong>News</strong> <span>Read and contribute</span> <span>to the WHATWG blog</span></p></a>
-  <a href="https://checker.html5.org/"><p><strong>Html Checker</strong> <span>Validate your documents</span> <span>with an HTML checker</span></p></a>
+  <a href="https://checker.html5.org/"><p><strong>HTML checker</strong> <span>Validate your documents</span> <span>with an HTML checker</span></p></a>
   <a href="https://whatwg.org/mailing-list#help"><p><strong>Help</strong> <span>Send questions</span> and <span>help others</span> <span>in the <b>help@whatwg.org</b></span> <span>mailing list</span></p></a>
 
   <a href="https://whatwg.org/mailing-list"><p><strong>Join</strong> <span>Comment on</span> <span>our Web standards</span> <span>and send proposals</span> <span>of your own</span></p></a>

--- a/src/mailing-list
+++ b/src/mailing-list
@@ -1,9 +1,9 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+<!doctype html>
 <html>
  <head>
   <title>Web Hypertext Application Technology Working Group Mailing List</title>
-  <link rel="stylesheet" media="all" href="/style/tabbed-pages">
-  <link rel="icon" href="/images/icon">
+  <link rel="stylesheet" href="/style/tabbed-pages">
+  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
   <style type="text/css">
    div { border: solid thin silver; padding: 1em 1em 0 2em; margin: 2em; }
    div h2 { margin-top: 0; }
@@ -18,8 +18,7 @@
   </h1>
   <ul class="navigation">
    <li><a href="/" rel="faq">Home</a></li>
-   <li><a href="/demos/">Demos</a></li>
-   <li><a href="specs/">Specifications</a></li>
+   <li><a href="https://spec.whatwg.org/">Standards</a></li>
    <li class="this"><strong>Mailing List</strong></li>
   </ul>
   <p>We have several lists:</p>

--- a/src/mailing-list
+++ b/src/mailing-list
@@ -1,10 +1,10 @@
 <!doctype html>
-<html>
+<html lang="en">
  <head>
   <title>Web Hypertext Application Technology Working Group Mailing List</title>
   <link rel="stylesheet" href="/style/tabbed-pages">
   <link rel="icon" href="https://resources.whatwg.org/logo.svg">
-  <style type="text/css">
+  <style>
    div { border: solid thin silver; padding: 1em 1em 0 2em; margin: 2em; }
    div h2 { margin-top: 0; }
    div h2, div h3 { margin-left: -0.5em; }


### PR DESCRIPTION
Fixes #9. Also reference checker.html5.org rather than validator.nu as
@sideshowbarker keeps that more up-to-date.