### PR TITLE
Allow Internet Archive in robots.txt

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,3 +1,6 @@
+User-agent: archive.org_bot
+Disallow:
+
 User-agent: *
 Disallow: /specs/url/
 Disallow: /specs/web-apps/


### PR DESCRIPTION
Syntax found at
https://support.archive-it.org/hc/en-us/articles/208001096-Avoid-robots-exclusions.

Fixes #19.