### PR TITLE
Try harder to allow archive.org to index old specs

### DIFF
--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,6 +1,12 @@
 User-agent: archive.org_bot
 Disallow:
 
+User-agent: ia_archiver
+Disallow:
+
+User-agent: ia_archiver-web.archive.org
+Disallow:
+
 User-agent: *
 Disallow: /specs/url/
 Disallow: /specs/web-apps/


### PR DESCRIPTION
See http://webmasters.stackexchange.com/q/71377/11849. Hopefully fixes #19 better.