### PR TITLE
Move the FAQ here

### DIFF
--- a/src/.htaccess
+++ b/src/.htaccess
@@ -84,7 +84,6 @@ redirect permanent /x https://xhr.spec.whatwg.org/
 redirect permanent /xhr https://xhr.spec.whatwg.org/
 
 redirect permanent /newbug https://github.com/whatwg/html/issues/new
-redirect permanent /faq https://wiki.whatwg.org/wiki/FAQ
 
 # redirect permanent /) https://whatwg.org/
 redirect permanent /mailing-list) https://whatwg.org/mailing-list

--- a/src/code-of-conduct
+++ b/src/code-of-conduct
@@ -16,6 +16,7 @@
    <li><a href="https://spec.whatwg.org/">Standards</a></li>
    <li><a href="/working-mode">Working Mode</a></li>
    <li class="this"><strong>Code of Conduct</strong></li>
+   <li><a href="/faq">FAQ</a></li>
   </ul>
 
   <h2>Code of Conduct</h2>

--- a/src/faq
+++ b/src/faq
@@ -1,0 +1,315 @@
+<!doctype html>
+<html lang="en">
+ <head>
+  <title>Web Hypertext Application Technology Working Group FAQ</title>
+  <link rel="stylesheet" href="/style/tabbed-pages">
+  <link rel="icon" href="https://resources.whatwg.org/logo.svg">
+  <style>
+   h3 { border-bottom: 1px solid #aaa; }
+   h4, h5, h6 { font-size: 1.1em; }
+   li p { margin: 0; }
+  </style>
+ </head>
+ <body>
+  <h1>
+   <span class="the">The</span>
+   <strong class="what">Web Hypertext Application Technology</strong>
+   <span class="wg">Working Group</span>
+  </h1>
+  <ul class="navigation">
+   <li><a href="/" rel="home">Home</a></li>
+   <li><a href="https://spec.whatwg.org/">Standards</a></li>
+   <li><a href="/working-mode">Working Mode</a></li>
+   <li><a href="/code-of-conduct">Code of Conduct</a></li>
+   <li class="this"><strong>FAQ</strong></li>
+  </ul>
+
+  <h2>FAQ</h2>
+
+  <h3 id="the-whatwg">The WHATWG<a class="self-link" href="#the-whatwg"></a></h3>
+
+  <h4 id="what-is-the-whatwg">What is the WHATWG?<a class="self-link" href="#what-is-the-whatwg"></a></h4>
+
+  <p>The Web Hypertext Application Technology Working Group (WHATWG) is a growing community of
+  people interested in evolving the Web. It focuses primarily on the development of HTML and APIs
+  needed for Web applications.
+
+  <p>The WHATWG was founded by individuals of Apple, the Mozilla Foundation, and Opera Software in
+  2004, after a W3C workshop. Apple, Mozilla and Opera were becoming increasingly concerned about
+  the W3C’s direction with XHTML, lack of interest in HTML and apparent disregard for the needs of
+  real-world authors. So, in response, these organisations set out with a mission to address these
+  concerns and the Web Hypertext Application Technology Working Group was born.
+
+  <h4 id="spell-and-pronounce">How do you spell and pronounce WHATWG?<a class="self-link" href="#spell-and-pronounce"></a></h4>
+
+  <p>It is spelled WHATWG, all uppercase, no spaces. It has various pronunciations: what-wee-gee,
+  what-wig, what-double-you-gee.
+
+  <h4 id="what-is-the-whatwg-working-on">What is the WHATWG working on?<a class="self-link" href="#what-is-the-whatwg-working-on"></a></h4>
+
+  <p>The WHATWG's main focus is Web standards, specifically:
+
+  <ul>
+   <li><p><a href="https://html.spec.whatwg.org/multipage/">HTML</a>, which also includes Web
+   Workers, Web Storage, the Web Sockets API, Server-Sent Events, Microdata, and the 2D Canvas.
+
+   <li><p><a href="https://fetch.spec.whatwg.org/">Fetch</a>, including the <code>fetch()</code> API
+
+   <li><p><a href="https://dom.spec.whatwg.org/">DOM</a>, including DOM Events, DOM range, and
+   mutation observers
+
+   <li><p><a href="https://url.spec.whatwg.org/">URLs</a>, including an API for URLs
+  </ul>
+
+  <p>...and <a href="https://spec.whatwg.org/">a number of other specs</a>.
+
+  <h4 id="get-involved">How can I get involved?<a class="self-link" href="#get-involved"></a></h4>
+
+  <p>There are lots of ways you can get involved, take a look and see
+  <i><a href="https://wiki.whatwg.org/wiki/What_you_can_do">What you can do</a></i>!
+
+  <p><a href="https://www.youtube.com/watch?v=hneN6aW-d9w">This video from Domenic Denicola</a> is a
+  good introduction to working with standards bodies.
+
+  <h4 id="is-participation-free">Is participation free?<a class="self-link" href="#is-participation-free"></a></h4>
+
+  <p>Yes, everyone can contribute. There are no memberships fees involved, it's an open process. You
+  may easily <a href="https://github.com/whatwg">participate on GitHub</a> or subscribe to the
+  <a href="/mailing-list">WHATWG mailing lists</a>. There are no meetings, since meetings prevent
+  people with limited time or money from participating.
+
+  <h4 id="code-of-conduct">Is there a Code of Conduct?<a class="self-link" href="#code-of-conduct"></a></h4>
+
+  <p>Yes, see <a href="/code-of-conduct">Code of Conduct</a>. Please read it and respect it.
+
+  <h3 id="process">The WHATWG Process<a class="self-link" href="#process"></a></h3>
+
+  <h4 id="how-does-the-whatwg-work">How does the WHATWG work?<a class="self-link" href="#how-does-the-whatwg-work"></a></h4>
+
+  <p>People <a href="https://github.com/whatwg">collaborate on GitHub</a> or send email to
+  <a href="/mailing-list#specs">the mailing list</a>.
+
+  <p>Each standard has one or more editors, who are responsible for dealing with feedback for that
+  document. Those editors read all the feedback, and, taking it into account along with research,
+  studies, and feedback from many other sources (blogs, forums, IRC, etc.) make language design
+  decisions intended to address everyone's needs as well as possible while keeping the languages and
+  APIs consistent.
+
+  <p>This continues, with people sending more feedback, until nobody is able to convince the
+  relevant editor to change the spec any more (e.g., because two people want opposite things, and
+  the editor has considered all the information available and decided that one of the two proposals
+  is the better one).
+
+  <p>For new features, or significant changes to the processing models, the relevant editor will
+  typically describe the intended changes in the relevant bug or mailing list thread to give people
+  a chance to point out problems with it before the spec is updated. Implementors, especially, are
+  urged to indicate on such threads whether they approve of the suggested changes or new feature, so
+  that we can avoid the spec containing material which implementors are later found to disagree
+  with.
+
+  <p>This is not a consensus-based approach — there's no guarantee that everyone will be happy!
+  There is also no voting. There is a small oversight committee (known historically as the "WHATWG
+  members", from the name that the original <a href="/charter">charter</a> used, though that
+  terminology is misleading) who have the authority to override or replace editors if they start
+  making bad decisions, but so far that has never happened in over ten years. This committee has a
+  private mailing list, but it receives very few messages, usually going years with no emails at
+  all. Discussions on that list are summarized and described on the public list, to make sure
+  everyone is kept up to date.
+
+  <h4 id="what-happens-with-discussions">What happens with WHATWG mailing list/GitHub issue discussions?<a class="self-link" href="#what-happens-with-discussions"></a></h4>
+
+  <p>On the WHATWG list and in WHATWG issues on GitHub, the burden is on the spec editors to
+  evaluate the various positions that have been put forward in a discussion, and figure out which
+  one is strongest (or find another position that strikes a better balance between all of them).
+
+  <p>The purpose of debate at the WHATWG therefore isn't to convince everyone; it is to put forward
+  the arguments that exist, so that the relevant editor can make a well-informed decision. As a
+  corollary: If some points are made, rebutted, and not further defended, then maybe the person
+  making the arguments is hoping that the relevant editor will consider the rebuttals weak, or
+  thinks that the argument they have presented is strong despite the rebuttals. If you find someone
+  is not making good arguments, or is ignoring your arguments, your best bet is to stop responding.
+  Repeating previously-stated arguments doesn't help, since the editors will see all the arguments
+  when they look at the thread. Similarly, as soon as threads start being meta-threads about
+  people's argumentation behaviour, we stop making any kind of useful progress, since that isn't
+  input that can help the decision-making process later.
+
+  <h4 id="how-to-interact">How should tool developers, screen reader developers, browser vendors, search engine vendors, and other implementors interact with the WHATWG?<a class="self-link" href="#how-to-interact"></a></h4>
+
+  <p>File an issue on the <a href="https://spec.whatwg.org/">relevant standard</a> as indicated at
+  the top of that standard. All feedback is supposed to be addressed in due course. You are also
+  welcome to take a stab at addressing the problem yourself through a GitHub pull request.
+
+  <p><b>If you want feedback to be dealt with faster than "eventually", e.g., because you are about
+  to work on that feature and need the spec to be updated to take into account all previous
+  feedback, let the editors know</b> by either emailing them, or contacting them on
+  <a href="https://wiki.whatwg.org/wiki/IRC">IRC</a>. Requests for priority feedback handling are
+  handled confidentially if desired so other implementers won't know that you are working on that
+  feature.
+
+  <h4 id="removing-bad-ideas">Is there a process for removing bad ideas from a specification?<a class="self-link" href="#removing-bad-ideas"></a></h4>
+
+  <p>There are several processes by which we trim weeds from the specifications.
+
+  <ul>
+   <li><p>Occasionally, we go through every section and mark areas as being considered for removal.
+   This happened early in 2008 with the data templates, repetition blocks, and DFN-element cross
+   references, for example. If no feedback is received to give us strong reasons to keep such
+   features, then they eventually are removed altogether.
+
+   <li><p>Anyone can ask for a feature to be removed; such feedback is considered like all other
+   feedback and is based on the merits of the arguments put forward. If it's been a few years and
+   there's no implementation, and no vendor is showing any interest in eventually implementing that
+   section; or if it's a section that browsers previously implemented but where the momentum shows
+   that browsers are actually removing support, then it is highly likely that the request to remove
+   the section will be honoured. (Sometimes, a warning is first placed in the spec, as
+   with <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dialogs-implemented-using-separate-documents">showModalDialog()</a>.)
+
+   <li><p>If browsers don't widely implement a feature, or if authors don't use a feature, or if the
+   uses of the feature are inconsequential or fundamentally wrong or damaging, then, after due
+   consideration, features will be removed.
+  </ul>
+
+  <p>Removing features is a critical part of spec development.
+
+  <h4 id="adding-new-features">Is there a process for adding new features to a specification?<a class="self-link" href="#adding-new-features"></a></h4>
+
+  <p>The process is rather informal, but basically boils down to this:
+
+  <ol>
+   <li><p>Forget about the particular solution you have in mind! Solution time is later!
+
+   <li><p>Write down a description of the underlying problem you're trying to solve. What are the
+   use cases? A use case is an actual user wanting to do something. Then list requirements for each
+   use case. For a good example of how to do this, see
+   <a href="http://lists.w3.org/Archives/Public/public-webapps/2012JulSep/0835.html">this email</a>.
+
+   <li><p>Get more people involved. Open a new issue in
+   <a href="https://github.com/whatwg/html/issues">whatwg/html on GitHub</a> that describes the use
+   cases and their requirements. Ask fellow Web developers about their opinions (but remind them of
+   step 1 above). Adjust the list of use cases and requirements as appropriate. Say which use cases
+   are important and which are just nice to have.
+
+   <li><p>Optionally, your work is done at this point. If you have done a good job of the above
+   steps and convinced other people that your use case is an important one to solve, they can do the
+   remaining steps. (On the flip side, if nobody else cares about the use case, chances are
+   solutions for it will not succeed despite being awesome.)
+
+   <li><p>Research existing solutions. Come up with new solutions. Try to keep the solutions as
+   simple as possible, maybe only addressing the important use cases and leaving the nice to have
+   use cases for later (when there's implementation experience). Send this list of solutions, old
+   and new, as a comment on the feature's issue. Ask browser vendors for feedback. Maybe some
+   particular solutions don't fit with the browser's architecture, optimizations, etc., and just are
+   not going to be implemented no matter how much you like them. Strike those solutions and don't
+   grieve about the loss!
+
+   <li><p>Evaluate how well each of the remaining solutions address each use case and how well they
+   meet the requirements. This step should show which solution is the technically best fit (might
+   turn out to be someone else's solution).
+
+   <li><p>Ask the spec's editor to put that solution in the spec, or create a pull request on GitHub
+   yourself. Possibly your text won't be taken verbatim but will be written in a style that is more
+   suitable for implementors or better hooks in to the rest of the spec, etc.
+
+   <li><p>Ask browser vendors to implement the newly specified solution, even if it's just an
+   experimental implementation. This implementation experience usually means that new problems are
+   found with the solution that need to be addressed, or that a different solution is actually
+   better.
+
+   <li><p>Write a test suite for the feature to see if the implementations match the spec. This
+   usually highlights bugs in the implementations and also bugs in the spec.
+
+   <li><p>Participate in subsequent design discussions. When there are two or more mature
+   implementations, it may be time to extend the feature to address the nice to have use cases (but
+   this whole process should be repeated even for such extensions).
+  </ol>
+
+  <p>If the idea survives the above design process, the spec will be eventually updated to reflect
+  the new design. Implementations will then be updated to reflect the new design (if they aren't,
+  that indicates the new design is not good, and it will be reworked or removed). The spec will be
+  updated to fix the many problems discovered by authors and implementors, over a period of several
+  years, as more authors and implementors are exposed to the design. Eventually, a number of
+  provably interoperable implementations are deployed. At this point development of the feature is
+  somewhat frozen.
+
+  <p>Writing a comprehensive test suite is also an important step, which can even start before
+  implementations start being written to the spec. Cross-browser tests for HTML are maintained in
+  <a href="https://github.com/w3c/web-platform-tests/tree/master/html">w3c/web-platform-tests/html
+  on GitHub</a>.
+
+  <h4 id="should-i-send-new-proposed-text">Should I send new proposed text when I have a suggestion?<a class="self-link" href="#should-i-send-new-proposed-text"></a></h4>
+
+  <p>Please do not suggest new text, instead, say what is wrong with the current text. Just
+  proposing new text makes it impossible for the editor to determine if the problem is endemic
+  (requiring more changes than you realise), or whether what the editor thinks of as mistakes in the
+  new proposed text are intentional or not (and should be fixed or not), or whether stylistic
+  differences are intentional or not, etc.
+
+  <h4 id="living-standard">What does "Living Standard" mean?<a class="self-link" href="#living-standard"></a></h4>
+
+  <p>The WHATWG specifications are described as Living Standards. This means that they are standards
+  that are continuously updated as they receive feedback, either from Web designers, browser
+  vendors, tool vendors, or indeed any other interested party. It also means that new features get
+  added to them over time, at a rate intended to keep the specifications a little ahead of the
+  implementations but not so far ahead that the implementations give up.
+
+  <p>Despite the continuous maintenance, or maybe we should say <i>as part</i> of the continuing
+  maintenance, a significant effort is placed on getting the specifications and the implementations
+  to converge — the parts of the specification that are mature and stable are not changed willy
+  nilly. Maintenance means that the days where the specifications are brought down from the mountain
+  and remain forever locked, even if it turns out that all the browsers do something else, or even
+  if it turns out that the specification left some detail out and the browsers all disagree on how
+  to implement it, are gone. Instead, we now make sure to update the specifications to be detailed
+  enough that all the implementations (not just browsers, of course) can do the same thing. Instead
+  of ignoring what the browsers do, we fix the spec to match what the browsers do. Instead of
+  leaving the specification ambiguous, we fix the the specification to define how things work.
+
+  <h4 id="change-at-any-time">Does that mean the specifications can change at any time?<a class="self-link" href="#change-at-any-time"></a></h4>
+
+  <p>The specifications do not change arbitrarily: we are extremely careful! As parts of a
+  specification mature, and implementations ship, the spec cannot be changed in
+  backwards-incompatible ways (because the implementors would never agree to break compatibility
+  unless for security reasons). The specifications are never complete, since the Web is continuously
+  evolving. The last time HTML was described as "complete" was after HTML4, when development stopped
+  for several years, leading to stagnation. (If the Web is replaced by something better and dies,
+  the HTML spec will die with it.)
+
+  <p>For references to stable copies of the specifications, some WHATWG specifications follows a
+  process by which each change to the specification (embodied in a commit) triggers the publication
+  of a frozen snapshot of the said specification.
+
+  <p>These snapshots are published as historical references. The WHATWG intends to keep these frozen
+  snapshots available at their published URL permanently.
+
+  <h4 id="patent-policy">What's the patent story for WHATWG standards?<a class="self-link" href="#patent-policy"></a></h4>
+
+  <p>The WHATWG operates as a W3C Community Group and thus uses the W3C Community Group patent
+  policies. So far we have published one FSA with
+  <a href="http://www.w3.org/community/whatwg/spec/82/commitments">patent commitments</a> from
+  Google, Mozilla, and others covering the URL standard.
+  <a href="https://blog.whatwg.org/make-patent-commitments">You can make patent commitments too!</a>
+  Some of our specifications have also been forked and republished by the W3C with patent
+  commitments from certain companies.
+
+  <h4 id="translating">What is the process for translating WHATWG standards?<a class="self-link" href="#translating"></a></h4>
+
+  <p>Many WHATWG standards have been translated into other languages by the WHATWG community. This
+  is great, and highly encouraged!
+
+  <p>In general, if you translate a WHATWG Standard, please communicate with the maintainers of the
+  standard (e.g. via a GitHub issue) letting them know about your work. In general this will lead to
+  adding a link to your translation to the top of the original specification, to allow interested
+  readers to view it. You can see examples of this in many WHATWG standards, e.g.
+  <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>.
+
+  <p>Such translations are not normative (i.e., implementations should be sure to consult the
+  original). Due to the nature of living standards, which can change often, it's possible for
+  translations to become out of date compared to the original standard. If the translation shows
+  signs of no longer being maintained, or has other quality problems, community members are
+  encouraged to provide feedback to the maintainers of the standard, so that any links to the
+  translation can be removed in order to avoid confusing readers.
+
+  <p>Note that WHATWG specifications are always licensed under liberal licenses that allow the
+  creation of derivative works like translations.
+
+ </body>
+</html>

--- a/src/faq
+++ b/src/faq
@@ -47,7 +47,7 @@
 
   <h4 id="what-is-the-whatwg-working-on">What is the WHATWG working on?<a class="self-link" href="#what-is-the-whatwg-working-on"></a></h4>
 
-  <p>The WHATWG's main focus is Web standards, specifically:
+  <p>The WHATWG’s main focus is Web standards, specifically:
 
   <ul>
    <li><p><a href="https://html.spec.whatwg.org/multipage/">HTML</a>, which also includes Web
@@ -66,21 +66,17 @@
   <h4 id="get-involved">How can I get involved?<a class="self-link" href="#get-involved"></a></h4>
 
   <p>There are lots of ways you can get involved, take a look and see
-  <i><a href="https://wiki.whatwg.org/wiki/What_you_can_do">What you can do</a></i>!
+  <a href="https://wiki.whatwg.org/wiki/What_you_can_do">What you can do</a>!
 
   <p><a href="https://www.youtube.com/watch?v=hneN6aW-d9w">This video from Domenic Denicola</a> is a
   good introduction to working with standards bodies.
 
   <h4 id="is-participation-free">Is participation free?<a class="self-link" href="#is-participation-free"></a></h4>
 
-  <p>Yes, everyone can contribute. There are no memberships fees involved, it's an open process. You
+  <p>Yes, everyone can contribute. There are no memberships fees involved, it’s an open process. You
   may easily <a href="https://github.com/whatwg">participate on GitHub</a> or subscribe to the
   <a href="/mailing-list">WHATWG mailing lists</a>. There are no meetings, since meetings prevent
   people with limited time or money from participating.
-
-  <h4 id="code-of-conduct">Is there a Code of Conduct?<a class="self-link" href="#code-of-conduct"></a></h4>
-
-  <p>Yes, see <a href="/code-of-conduct">Code of Conduct</a>. Please read it and respect it.
 
   <h3 id="process">The WHATWG Process<a class="self-link" href="#process"></a></h3>
 
@@ -92,7 +88,7 @@
   <p>Each standard has one or more editors, who are responsible for dealing with feedback for that
   document. Those editors read all the feedback, and, taking it into account along with research,
   studies, and feedback from many other sources (blogs, forums, IRC, etc.) make language design
-  decisions intended to address everyone's needs as well as possible while keeping the languages and
+  decisions intended to address everyone’s needs as well as possible while keeping the languages and
   APIs consistent.
 
   <p>This continues, with people sending more feedback, until nobody is able to convince the
@@ -107,9 +103,9 @@
   that we can avoid the spec containing material which implementors are later found to disagree
   with.
 
-  <p>This is not a consensus-based approach — there's no guarantee that everyone will be happy!
-  There is also no voting. There is a small oversight committee (known historically as the "WHATWG
-  members", from the name that the original <a href="/charter">charter</a> used, though that
+  <p>This is not a consensus-based approach — there’s no guarantee that everyone will be happy!
+  There is also no voting. There is a small oversight committee (known historically as the “WHATWG
+  members”, from the name that the original <a href="/charter">charter</a> used, though that
   terminology is misleading) who have the authority to override or replace editors if they start
   making bad decisions, but so far that has never happened in over ten years. This committee has a
   private mailing list, but it receives very few messages, usually going years with no emails at
@@ -122,15 +118,15 @@
   evaluate the various positions that have been put forward in a discussion, and figure out which
   one is strongest (or find another position that strikes a better balance between all of them).
 
-  <p>The purpose of debate at the WHATWG therefore isn't to convince everyone; it is to put forward
+  <p>The purpose of debate at the WHATWG therefore isn’t to convince everyone; it is to put forward
   the arguments that exist, so that the relevant editor can make a well-informed decision. As a
   corollary: If some points are made, rebutted, and not further defended, then maybe the person
   making the arguments is hoping that the relevant editor will consider the rebuttals weak, or
   thinks that the argument they have presented is strong despite the rebuttals. If you find someone
   is not making good arguments, or is ignoring your arguments, your best bet is to stop responding.
-  Repeating previously-stated arguments doesn't help, since the editors will see all the arguments
+  Repeating previously-stated arguments doesn’t help, since the editors will see all the arguments
   when they look at the thread. Similarly, as soon as threads start being meta-threads about
-  people's argumentation behaviour, we stop making any kind of useful progress, since that isn't
+  people’s argumentation behaviour, we stop making any kind of useful progress, since that isn’t
   input that can help the decision-making process later.
 
   <h4 id="how-to-interact">How should tool developers, screen reader developers, browser vendors, search engine vendors, and other implementors interact with the WHATWG?<a class="self-link" href="#how-to-interact"></a></h4>
@@ -139,11 +135,11 @@
   the top of that standard. All feedback is supposed to be addressed in due course. You are also
   welcome to take a stab at addressing the problem yourself through a GitHub pull request.
 
-  <p><b>If you want feedback to be dealt with faster than "eventually", e.g., because you are about
-  to work on that feature and need the spec to be updated to take into account all previous
-  feedback, let the editors know</b> by either emailing them, or contacting them on
+  <p>If you want feedback to be dealt with faster than “eventually”, e.g., because you are about to
+  work on that feature and need the spec to be updated to take into account all previous feedback,
+  let the editors know by either emailing them, or contacting them on
   <a href="https://wiki.whatwg.org/wiki/IRC">IRC</a>. Requests for priority feedback handling are
-  handled confidentially if desired so other implementers won't know that you are working on that
+  handled confidentially if desired so other implementers won’t know that you are working on that
   feature.
 
   <h4 id="removing-bad-ideas">Is there a process for removing bad ideas from a specification?<a class="self-link" href="#removing-bad-ideas"></a></h4>
@@ -157,14 +153,13 @@
    features, then they eventually are removed altogether.
 
    <li><p>Anyone can ask for a feature to be removed; such feedback is considered like all other
-   feedback and is based on the merits of the arguments put forward. If it's been a few years and
-   there's no implementation, and no vendor is showing any interest in eventually implementing that
-   section; or if it's a section that browsers previously implemented but where the momentum shows
+   feedback and is based on the merits of the arguments put forward. If it’s been a few years and
+   there’s no implementation, and no vendor is showing any interest in eventually implementing that
+   section; or if it’s a section that browsers previously implemented but where the momentum shows
    that browsers are actually removing support, then it is highly likely that the request to remove
-   the section will be honoured. (Sometimes, a warning is first placed in the spec, as
-   with <a href="https://html.spec.whatwg.org/multipage/webappapis.html#dialogs-implemented-using-separate-documents">showModalDialog()</a>.)
+   the section will be honoured. (Sometimes, a warning is first placed in the spec.)
 
-   <li><p>If browsers don't widely implement a feature, or if authors don't use a feature, or if the
+   <li><p>If browsers don’t widely implement a feature, or if authors don’t use a feature, or if the
    uses of the feature are inconsequential or fundamentally wrong or damaging, then, after due
    consideration, features will be removed.
   </ul>
@@ -178,7 +173,7 @@
   <ol>
    <li><p>Forget about the particular solution you have in mind! Solution time is later!
 
-   <li><p>Write down a description of the underlying problem you're trying to solve. What are the
+   <li><p>Write down a description of the underlying problem you’re trying to solve. What are the
    use cases? A use case is an actual user wanting to do something. Then list requirements for each
    use case. For a good example of how to do this, see
    <a href="http://lists.w3.org/Archives/Public/public-webapps/2012JulSep/0835.html">this email</a>.
@@ -196,21 +191,21 @@
 
    <li><p>Research existing solutions. Come up with new solutions. Try to keep the solutions as
    simple as possible, maybe only addressing the important use cases and leaving the nice to have
-   use cases for later (when there's implementation experience). Send this list of solutions, old
-   and new, as a comment on the feature's issue. Ask browser vendors for feedback. Maybe some
-   particular solutions don't fit with the browser's architecture, optimizations, etc., and just are
-   not going to be implemented no matter how much you like them. Strike those solutions and don't
+   use cases for later (when there’s implementation experience). Send this list of solutions, old
+   and new, as a comment on the feature’s issue. Ask browser vendors for feedback. Maybe some
+   particular solutions don’t fit with the browser’s architecture, optimizations, etc., and just are
+   not going to be implemented no matter how much you like them. Strike those solutions and don’t
    grieve about the loss!
 
    <li><p>Evaluate how well each of the remaining solutions address each use case and how well they
    meet the requirements. This step should show which solution is the technically best fit (might
-   turn out to be someone else's solution).
+   turn out to be someone else’s solution).
 
-   <li><p>Ask the spec's editor to put that solution in the spec, or create a pull request on GitHub
-   yourself. Possibly your text won't be taken verbatim but will be written in a style that is more
+   <li><p>Ask the spec’s editor to put that solution in the spec, or create a pull request on GitHub
+   yourself. Possibly your text won’t be taken verbatim but will be written in a style that is more
    suitable for implementors or better hooks in to the rest of the spec, etc.
 
-   <li><p>Ask browser vendors to implement the newly specified solution, even if it's just an
+   <li><p>Ask browser vendors to implement the newly specified solution, even if it’s just an
    experimental implementation. This implementation experience usually means that new problems are
    found with the solution that need to be addressed, or that a different solution is actually
    better.
@@ -224,7 +219,7 @@
   </ol>
 
   <p>If the idea survives the above design process, the spec will be eventually updated to reflect
-  the new design. Implementations will then be updated to reflect the new design (if they aren't,
+  the new design. Implementations will then be updated to reflect the new design (if they aren’t,
   that indicates the new design is not good, and it will be reworked or removed). The spec will be
   updated to fix the many problems discovered by authors and implementors, over a period of several
   years, as more authors and implementors are exposed to the design. Eventually, a number of
@@ -244,7 +239,7 @@
   new proposed text are intentional or not (and should be fixed or not), or whether stylistic
   differences are intentional or not, etc.
 
-  <h4 id="living-standard">What does "Living Standard" mean?<a class="self-link" href="#living-standard"></a></h4>
+  <h4 id="living-standard">What does “Living Standard” mean?<a class="self-link" href="#living-standard"></a></h4>
 
   <p>The WHATWG specifications are described as Living Standards. This means that they are standards
   that are continuously updated as they receive feedback, either from Web designers, browser
@@ -269,7 +264,7 @@
   specification mature, and implementations ship, the spec cannot be changed in
   backwards-incompatible ways (because the implementors would never agree to break compatibility
   unless for security reasons). The specifications are never complete, since the Web is continuously
-  evolving. The last time HTML was described as "complete" was after HTML4, when development stopped
+  evolving. The last time HTML was described as “complete” was after HTML4, when development stopped
   for several years, leading to stagnation. (If the Web is replaced by something better and dies,
   the HTML spec will die with it.)
 
@@ -280,7 +275,7 @@
   <p>These snapshots are published as historical references. The WHATWG intends to keep these frozen
   snapshots available at their published URL permanently.
 
-  <h4 id="patent-policy">What's the patent story for WHATWG standards?<a class="self-link" href="#patent-policy"></a></h4>
+  <h4 id="patent-policy">What’s the patent story for WHATWG standards?<a class="self-link" href="#patent-policy"></a></h4>
 
   <p>The WHATWG operates as a W3C Community Group and thus uses the W3C Community Group patent
   policies. So far we have published one FSA with
@@ -302,7 +297,7 @@
   <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>.
 
   <p>Such translations are not normative (i.e., implementations should be sure to consult the
-  original). Due to the nature of living standards, which can change often, it's possible for
+  original). Due to the nature of living standards, which can change often, it’s possible for
   translations to become out of date compared to the original standard. If the translation shows
   signs of no longer being maintained, or has other quality problems, community members are
   encouraged to provide feedback to the maintainers of the standard, so that any links to the

--- a/src/specs/index
+++ b/src/specs/index
@@ -17,6 +17,7 @@
    <li class="this"><strong>Standards</strong></li>
    <li><a href="https://whatwg.org/working-mode">Working Mode</a></li>
    <li><a href="https://whatwg.org/code-of-conduct">Code of Conduct</a></li>
+   <li><a href="https://whatwg.org/faq">FAQ</a></li>
   </ul>
 
   <p>The WHATWG works on a number of technologies that are fundamental parts of the web platform.

--- a/src/working-mode
+++ b/src/working-mode
@@ -16,6 +16,7 @@
    <li><a href="https://spec.whatwg.org/">Standards</a></li>
    <li class="this"><strong>Working Mode</strong></li>
    <li><a href="/code-of-conduct">Code of Conduct</a></li>
+   <li><a href="/faq">FAQ</a></li>
   </ul>
 
   <h2>Working Mode</h2>


### PR DESCRIPTION
This was produced starting from the HTML output of
https://wiki.whatwg.org/wiki/FAQ and cleaning it up to match the style
of /working-mode and /code-of-conduct. Only very minor visible changes
were made around whitespace, quotes and similar. Actual changes to the
FAQ will be made separately.

Some minimal amount of style is carried over or invented to make it not
much worse than the old FAQ.

All IDs are preserved.