### PR TITLE
Update links to wiki/FAQ

### DIFF
--- a/src/faq
+++ b/src/faq
@@ -26,6 +26,9 @@
 
   <h2>FAQ</h2>
 
+  <p><i>See also the
+  <a href="https://github.com/whatwg/html/blob/master/FAQ.md">HTML Standard FAQ</a>.</i>
+
   <h3 id="the-whatwg">The WHATWG<a class="self-link" href="#the-whatwg"></a></h3>
 
   <h4 id="what-is-the-whatwg">What is the WHATWG?<a class="self-link" href="#what-is-the-whatwg"></a></h4>

--- a/src/index
+++ b/src/index
@@ -11,7 +11,7 @@
    <h2>Maintaining and evolving HTML since 2004</h2>
   </hgroup>
 
-  <a href="https://wiki.whatwg.org/wiki/FAQ"><p><strong>FAQ</strong> <span>Get answers</span> <span>to your questions</span> <span>about HTML</span> <span>and the WHATWG</span></p></a>
+  <a href="/faq"><p><strong>FAQ</strong> <span>Get answers</span> <span>to your questions</span> <span>about the WHATWG</span></p></a>
   <a href="https://html.spec.whatwg.org/multipage/"><p><strong>HTML</strong> <span>Read, use,</span> <span>or implement</span> <span>the HTML Living Standard</span></p></a>
   <a href="https://spec.whatwg.org/"><p><strong>Standards</strong> <span>See the other</span> standards <span>developed at the WHATWG</span></p></a>
 

--- a/src/specs/index
+++ b/src/specs/index
@@ -133,7 +133,7 @@
   </dl>
 
   <p>For more details, please see <a
-  href="https://wiki.whatwg.org/wiki/FAQ#What_are_the_various_versions_of_the_HTML_spec.3F">the
+  href="https://github.com/whatwg/html/blob/master/FAQ.md#what-are-the-various-versions-of-the-html-spec">the
   relevant FAQ entry</a>.</p>
 
  </body>


### PR DESCRIPTION
... and link to the HTML FAQ from the WHATWG FAQ, since the main page
points to it and people may be looking for that content.