### PR TITLE
Move Books and Figures to idea.whatwg.org

### DIFF
--- a/src/specs/index
+++ b/src/specs/index
@@ -122,6 +122,6 @@
   </dl>
 
   <p>The WHATWG also works on a <a href="https://idea.whatwg.org/">number of ideas</a> that aspire
-  to standards one day.</p>
+  to become standards one day.</p>
  </body>
 </html>

--- a/src/specs/index
+++ b/src/specs/index
@@ -20,12 +20,13 @@
    <li><a href="https://whatwg.org/faq">FAQ</a></li>
   </ul>
 
+  <h2>Standards</h2>
+
   <p>The WHATWG works on a number of technologies that are fundamental parts of the web platform.
   They are organised somewhat arbitrarily based on the preferences of those editing the standard for
   those technologies.</p>
 
   <dl>
-
    <dt><a href="https://html.spec.whatwg.org/multipage/">HTML</a></dt>
    <dd>
     <p>The HTML Standard is a kitchen sink full of technologies for
@@ -112,29 +113,15 @@
     integrate well with those of the web platform.</p>
    </dd>
 
-   <dt><a href="https://books.spec.whatwg.org/">Books</a></dt>
-   <dd>
-    <p>The Books Standard defines CSS features for book publishing and high-quality printing of web
-    pages.</p>
-   </dd>
-
-   <dt><a href="https://figures.spec.whatwg.org/">Figures</a></dt>
-   <dd>
-    <p>The Figures Standard defines CSS features for floating elements around pages and columns.</p>
-   </dd>
-
    <dt><a href="https://quirks.spec.whatwg.org/">Quirks Mode</a></dt>
    <dd>
     <p>The Quirks Mode Standard describes behaviours in CSS and Selectors
     that are not yet defined in the relevant specifications but that
     are nonetheless widely implemented.</p>
    </dd>
-
   </dl>
 
-  <p>For more details, please see <a
-  href="https://github.com/whatwg/html/blob/master/FAQ.md#what-are-the-various-versions-of-the-html-spec">the
-  relevant FAQ entry</a>.</p>
-
+  <p>The WHATWG also works on a <a href="https://idea.whatwg.org/">number of ideas</a> that aspire
+  to standards one day.</p>
  </body>
 </html>


### PR DESCRIPTION
See https://github.com/whatwg/books/issues/4, https://github.com/whatwg/figures/issues/3, and https://github.com/whatwg/misc-server/issues/6.

Also remove a pointer to the HTML Standard FAQ as it's not really that useful.

Fix #37 while here.