### PR TITLE
Improve the FAQ

### DIFF
--- a/src/faq
+++ b/src/faq
@@ -228,7 +228,7 @@
   added to them over time, at a rate intended to keep the standard a little ahead of the
   implementations, but not so far ahead that the implementations give up.
 
-  <p>Despite the continuous maintenance, or maybe we should say <i>as part</i> of the continuing
+  <p>Despite the continuous maintenance, or maybe we should say <em>as part</em> of the continuing
   maintenance, a significant effort is placed on getting the standard and the implementations to
   converge — the parts of the standard that are mature and stable are not changed willy nilly.
   Maintenance means that the days where the standard are brought down from the mountain and remain

--- a/src/faq
+++ b/src/faq
@@ -33,15 +33,14 @@
 
   <h4 id="what-is-the-whatwg">What is the WHATWG?<a class="self-link" href="#what-is-the-whatwg"></a></h4>
 
-  <p>The Web Hypertext Application Technology Working Group (WHATWG) is a growing community of
-  people interested in evolving the Web. It focuses primarily on the development of HTML and APIs
-  needed for Web applications.
+  <p>The Web Hypertext Application Technology Working Group (WHATWG) is a community of people
+  interested in evolving the web through standards and tests.
 
   <p>The WHATWG was founded by individuals of Apple, the Mozilla Foundation, and Opera Software in
   2004, after a W3C workshop. Apple, Mozilla and Opera were becoming increasingly concerned about
-  the W3C’s direction with XHTML, lack of interest in HTML and apparent disregard for the needs of
-  real-world authors. So, in response, these organisations set out with a mission to address these
-  concerns and the Web Hypertext Application Technology Working Group was born.
+  the W3C’s direction with XHTML, lack of interest in HTML, and apparent disregard for the needs of
+  real-world web developers. So, in response, these organisations set out with a mission to address
+  these concerns and the Web Hypertext Application Technology Working Group was born.
 
   <h4 id="spell-and-pronounce">How do you spell and pronounce WHATWG?<a class="self-link" href="#spell-and-pronounce"></a></h4>
 
@@ -50,7 +49,7 @@
 
   <h4 id="what-is-the-whatwg-working-on">What is the WHATWG working on?<a class="self-link" href="#what-is-the-whatwg-working-on"></a></h4>
 
-  <p>The WHATWG’s main focus is Web standards, specifically:
+  <p>The WHATWG’s main focus is web standards and their associated tests, specifically:
 
   <ul>
    <li><p><a href="https://html.spec.whatwg.org/multipage/">HTML</a>, which also includes Web
@@ -61,10 +60,10 @@
    <li><p><a href="https://dom.spec.whatwg.org/">DOM</a>, including DOM Events, DOM range, and
    mutation observers
 
-   <li><p><a href="https://url.spec.whatwg.org/">URLs</a>, including an API for URLs
+   <li><p><a href="https://url.spec.whatwg.org/">URL</a>, including an API for URLs
   </ul>
 
-  <p>...and <a href="https://spec.whatwg.org/">a number of other specs</a>.
+  <p>...and <a href="https://spec.whatwg.org/">a number of other standards</a>.
 
   <h4 id="get-involved">How can I get involved?<a class="self-link" href="#get-involved"></a></h4>
 
@@ -85,41 +84,14 @@
 
   <h4 id="how-does-the-whatwg-work">How does the WHATWG work?<a class="self-link" href="#how-does-the-whatwg-work"></a></h4>
 
-  <p>People <a href="https://github.com/whatwg">collaborate on GitHub</a> or send email to
-  <a href="/mailing-list#specs">the mailing list</a>.
-
-  <p>Each standard has one or more editors, who are responsible for dealing with feedback for that
-  document. Those editors read all the feedback, and, taking it into account along with research,
-  studies, and feedback from many other sources (blogs, forums, IRC, etc.) make language design
-  decisions intended to address everyone’s needs as well as possible while keeping the languages and
-  APIs consistent.
-
-  <p>This continues, with people sending more feedback, until nobody is able to convince the
-  relevant editor to change the spec any more (e.g., because two people want opposite things, and
-  the editor has considered all the information available and decided that one of the two proposals
-  is the better one).
-
-  <p>For new features, or significant changes to the processing models, the relevant editor will
-  typically describe the intended changes in the relevant bug or mailing list thread to give people
-  a chance to point out problems with it before the spec is updated. Implementors, especially, are
-  urged to indicate on such threads whether they approve of the suggested changes or new feature, so
-  that we can avoid the spec containing material which implementors are later found to disagree
-  with.
-
-  <p>This is not a consensus-based approach — there’s no guarantee that everyone will be happy!
-  There is also no voting. There is a small oversight committee (known historically as the “WHATWG
-  members”, from the name that the original <a href="/charter">charter</a> used, though that
-  terminology is misleading) who have the authority to override or replace editors if they start
-  making bad decisions, but so far that has never happened in over ten years. This committee has a
-  private mailing list, but it receives very few messages, usually going years with no emails at
-  all. Discussions on that list are summarized and described on the public list, to make sure
-  everyone is kept up to date.
+  <p><a href="/working-mode">Working Mode</a> describes the day-to-day process in detail. Most of
+  the activity consists of <a href="https://github.com/whatwg">collaboration on GitHub</a>.
 
   <h4 id="what-happens-with-discussions">What happens with WHATWG mailing list/GitHub issue discussions?<a class="self-link" href="#what-happens-with-discussions"></a></h4>
 
-  <p>On the WHATWG list and in WHATWG issues on GitHub, the burden is on the spec editors to
-  evaluate the various positions that have been put forward in a discussion, and figure out which
-  one is strongest (or find another position that strikes a better balance between all of them).
+  <p>On the WHATWG list and in WHATWG issues on GitHub, the burden is on the editors to evaluate the
+  various positions that have been put forward in a discussion, and figure out which one is
+  strongest (or find another position that strikes a better balance between all of them).
 
   <p>The purpose of debate at the WHATWG therefore isn’t to convince everyone; it is to put forward
   the arguments that exist, so that the relevant editor can make a well-informed decision. As a
@@ -139,15 +111,15 @@
   welcome to take a stab at addressing the problem yourself through a GitHub pull request.
 
   <p>If you want feedback to be dealt with faster than “eventually”, e.g., because you are about to
-  work on that feature and need the spec to be updated to take into account all previous feedback,
-  let the editors know by either emailing them, or contacting them on
+  work on that feature and need the standard to be updated to take into account all previous
+  feedback, let the editors know by either emailing them, or contacting them on
   <a href="https://wiki.whatwg.org/wiki/IRC">IRC</a>. Requests for priority feedback handling are
   handled confidentially if desired so other implementers won’t know that you are working on that
   feature.
 
-  <h4 id="removing-bad-ideas">Is there a process for removing bad ideas from a specification?<a class="self-link" href="#removing-bad-ideas"></a></h4>
+  <h4 id="removing-bad-ideas">Is there a process for removing bad ideas from a standard?<a class="self-link" href="#removing-bad-ideas"></a></h4>
 
-  <p>There are several processes by which we trim weeds from the specifications.
+  <p>There are several processes by which we trim weeds:
 
   <ul>
    <li><p>Occasionally, we go through every section and mark areas as being considered for removal.
@@ -160,16 +132,16 @@
    there’s no implementation, and no vendor is showing any interest in eventually implementing that
    section; or if it’s a section that browsers previously implemented but where the momentum shows
    that browsers are actually removing support, then it is highly likely that the request to remove
-   the section will be honoured. (Sometimes, a warning is first placed in the spec.)
+   the section will be honoured. (Sometimes, a warning is first placed in the standard.)
 
    <li><p>If browsers don’t widely implement a feature, or if authors don’t use a feature, or if the
    uses of the feature are inconsequential or fundamentally wrong or damaging, then, after due
    consideration, features will be removed.
   </ul>
 
-  <p>Removing features is a critical part of spec development.
+  <p>Removing features is a critical part of standards development.
 
-  <h4 id="adding-new-features">Is there a process for adding new features to a specification?<a class="self-link" href="#adding-new-features"></a></h4>
+  <h4 id="adding-new-features">Is there a process for adding new features to a standard?<a class="self-link" href="#adding-new-features"></a></h4>
 
   <p>The process is rather informal, but basically boils down to this:
 
@@ -204,35 +176,34 @@
    meet the requirements. This step should show which solution is the technically best fit (might
    turn out to be someone else’s solution).
 
-   <li><p>Ask the spec’s editor to put that solution in the spec, or create a pull request on GitHub
+   <li><p>Ask the editor to put that solution in the standard, or create a pull request on GitHub
    yourself. Possibly your text won’t be taken verbatim but will be written in a style that is more
-   suitable for implementors or better hooks in to the rest of the spec, etc.
+   suitable for implementors or better hooks in to the rest of the standard, etc.
 
    <li><p>Ask browser vendors to implement the newly specified solution, even if it’s just an
    experimental implementation. This implementation experience usually means that new problems are
    found with the solution that need to be addressed, or that a different solution is actually
    better.
 
-   <li><p>Write a test suite for the feature to see if the implementations match the spec. This
-   usually highlights bugs in the implementations and also bugs in the spec.
+   <li><p>Write a test suite for the feature to see if the implementations match the standard. This
+   usually highlights bugs in the implementations and also bugs in the standard.
 
    <li><p>Participate in subsequent design discussions. When there are two or more mature
    implementations, it may be time to extend the feature to address the nice to have use cases (but
    this whole process should be repeated even for such extensions).
   </ol>
 
-  <p>If the idea survives the above design process, the spec will be eventually updated to reflect
-  the new design. Implementations will then be updated to reflect the new design (if they aren’t,
-  that indicates the new design is not good, and it will be reworked or removed). The spec will be
-  updated to fix the many problems discovered by authors and implementors, over a period of several
-  years, as more authors and implementors are exposed to the design. Eventually, a number of
-  provably interoperable implementations are deployed. At this point development of the feature is
-  somewhat frozen.
+  <p>If the idea survives the above design process, the standard will be eventually updated to
+  reflect the new design. Implementations will then be updated to reflect the new design (if they
+  aren’t, that indicates the new design is not good, and it will be reworked or removed). The
+  standard will be updated to fix the many problems discovered by authors and implementors, over a
+  period of several years, as more authors and implementors are exposed to the design. Eventually, a
+  number of provably interoperable implementations are deployed. At this point development of the
+  feature is somewhat frozen.
 
-  <p>Writing a comprehensive test suite is also an important step, which can even start before
-  implementations start being written to the spec. Cross-browser tests for HTML are maintained in
-  <a href="https://github.com/w3c/web-platform-tests/tree/master/html">w3c/web-platform-tests/html
-  on GitHub</a>.
+  <p>Writing a comprehensive test suite is also an important step, which should start before
+  implementations start being written to the standard. Cross-browser tests are maintained in
+  <a href="https://github.com/w3c/web-platform-tests">web-platform-tests on GitHub</a>.
 
   <h4 id="should-i-send-new-proposed-text">Should I send new proposed text when I have a suggestion?<a class="self-link" href="#should-i-send-new-proposed-text"></a></h4>
 
@@ -244,36 +215,36 @@
 
   <h4 id="living-standard">What does “Living Standard” mean?<a class="self-link" href="#living-standard"></a></h4>
 
-  <p>The WHATWG specifications are described as Living Standards. This means that they are standards
-  that are continuously updated as they receive feedback, either from Web designers, browser
+  <p>The WHATWG standards are described as Living Standards. This means that they are standards
+  that are continuously updated as they receive feedback, either from web designers, browser
   vendors, tool vendors, or indeed any other interested party. It also means that new features get
-  added to them over time, at a rate intended to keep the specifications a little ahead of the
-  implementations but not so far ahead that the implementations give up.
+  added to them over time, at a rate intended to keep the standard a little ahead of the
+  implementations, but not so far ahead that the implementations give up.
 
   <p>Despite the continuous maintenance, or maybe we should say <i>as part</i> of the continuing
-  maintenance, a significant effort is placed on getting the specifications and the implementations
-  to converge — the parts of the specification that are mature and stable are not changed willy
-  nilly. Maintenance means that the days where the specifications are brought down from the mountain
-  and remain forever locked, even if it turns out that all the browsers do something else, or even
-  if it turns out that the specification left some detail out and the browsers all disagree on how
-  to implement it, are gone. Instead, we now make sure to update the specifications to be detailed
-  enough that all the implementations (not just browsers, of course) can do the same thing. Instead
-  of ignoring what the browsers do, we fix the spec to match what the browsers do. Instead of
-  leaving the specification ambiguous, we fix the the specification to define how things work.
+  maintenance, a significant effort is placed on getting the standard and the implementations to
+  converge — the parts of the standard that are mature and stable are not changed willy nilly.
+  Maintenance means that the days where the standard are brought down from the mountain and remain
+  forever locked, even if it turns out that all the browsers do something else, or even if it turns
+  out that the standard left some detail out and the browsers all disagree on how to implement it,
+  are gone. Instead, we now make sure to update the standard to be detailed enough that all the
+  implementations (not just browsers, of course) can do the same thing. Instead of ignoring what the
+  browsers do, we fix the standard to match what the browsers do. Instead of leaving the standard
+  ambiguous, we fix the the standard to define how things work.
 
-  <h4 id="change-at-any-time">Does that mean the specifications can change at any time?<a class="self-link" href="#change-at-any-time"></a></h4>
+  <h4 id="change-at-any-time">Does that mean the standards can change at any time?<a class="self-link" href="#change-at-any-time"></a></h4>
 
-  <p>The specifications do not change arbitrarily: we are extremely careful! As parts of a
-  specification mature, and implementations ship, the spec cannot be changed in
-  backwards-incompatible ways (because the implementors would never agree to break compatibility
-  unless for security reasons). The specifications are never complete, since the Web is continuously
-  evolving. The last time HTML was described as “complete” was after HTML4, when development stopped
-  for several years, leading to stagnation. (If the Web is replaced by something better and dies,
-  the HTML spec will die with it.)
+  <p>The standards do not change arbitrarily: we are extremely careful! As parts of a standard
+  mature, and implementations ship, the standard cannot be changed in backwards-incompatible ways
+  (because the implementors would never agree to break compatibility unless for security reasons).
+  The standards are never complete, since the web is continuously evolving. The last time HTML was
+  described as “complete” was after HTML4, when development stopped for several years, leading to
+  stagnation. (If the web is replaced by something better and dies, the HTML standard will die with
+  it.)
 
-  <p>For references to stable copies of the specifications, some WHATWG specifications follows a
-  process by which each change to the specification (embodied in a commit) triggers the publication
-  of a frozen snapshot of the said specification.
+  <p>For references to stable copies of the standard, most WHATWG standards follows a process by
+  which each change to the standard (embodied in a commit) triggers the publication of a frozen
+  snapshot of the said standard.
 
   <p>These snapshots are published as historical references. The WHATWG intends to keep these frozen
   snapshots available at their published URL permanently.
@@ -285,8 +256,8 @@
   <a href="http://www.w3.org/community/whatwg/spec/82/commitments">patent commitments</a> from
   Google, Mozilla, and others covering the URL standard.
   <a href="https://blog.whatwg.org/make-patent-commitments">You can make patent commitments too!</a>
-  Some of our specifications have also been forked and republished by the W3C with patent
-  commitments from certain companies.
+  Some of our standards have also been forked and republished by the W3C with patent commitments
+  from certain companies.
 
   <h4 id="translating">What is the process for translating WHATWG standards?<a class="self-link" href="#translating"></a></h4>
 
@@ -295,9 +266,9 @@
 
   <p>In general, if you translate a WHATWG Standard, please communicate with the maintainers of the
   standard (e.g. via a GitHub issue) letting them know about your work. In general this will lead to
-  adding a link to your translation to the top of the original specification, to allow interested
-  readers to view it. You can see examples of this in many WHATWG standards, e.g.
-  <a href="https://streams.spec.whatwg.org/">https://streams.spec.whatwg.org/</a>.
+  adding a link to your translation to the top of the original standard, to allow interested readers
+  to view it. You can see examples of this in many WHATWG standards, e.g., the
+  <a href="https://streams.spec.whatwg.org/">Streams Standard</a>.
 
   <p>Such translations are not normative (i.e., implementations should be sure to consult the
   original). Due to the nature of living standards, which can change often, it’s possible for
@@ -306,8 +277,7 @@
   encouraged to provide feedback to the maintainers of the standard, so that any links to the
   translation can be removed in order to avoid confusing readers.
 
-  <p>Note that WHATWG specifications are always licensed under liberal licenses that allow the
-  creation of derivative works like translations.
-
+  <p>Note that WHATWG standards are always licensed under liberal licenses that allow the creation
+  of derivative works like translations.
  </body>
 </html>

--- a/src/faq
+++ b/src/faq
@@ -87,6 +87,13 @@
   <p><a href="/working-mode">Working Mode</a> describes the day-to-day process in detail. Most of
   the activity consists of <a href="https://github.com/whatwg">collaboration on GitHub</a>.
 
+  <p>In brief, each standard has one or more
+  <a href="https://whatwg.org/working-mode#editor">editors</a>, who guide its evolution. Like a
+  software project, a WHATWG standard undergoes
+  <a href="https://whatwg.org/faq#living-standard">continual maintenance</a>, and occasionally gets
+  <a href="https://whatwg.org/working-mode#additions">new features</a>. This work is driven by the
+  community in collaboration with implementers.
+
   <h4 id="what-happens-with-discussions">What happens with WHATWG mailing list/GitHub issue discussions?<a class="self-link" href="#what-happens-with-discussions"></a></h4>
 
   <p>On the WHATWG list and in WHATWG issues on GitHub, the burden is on the editors to evaluate the
@@ -180,13 +187,13 @@
    yourself. Possibly your text won’t be taken verbatim but will be written in a style that is more
    suitable for implementors or better hooks in to the rest of the standard, etc.
 
+   <li><p>Write a test suite for the feature to see if the implementations match the standard. This
+   usually highlights bugs in the implementations and also bugs in the standard.
+
    <li><p>Ask browser vendors to implement the newly specified solution, even if it’s just an
    experimental implementation. This implementation experience usually means that new problems are
    found with the solution that need to be addressed, or that a different solution is actually
    better.
-
-   <li><p>Write a test suite for the feature to see if the implementations match the standard. This
-   usually highlights bugs in the implementations and also bugs in the standard.
 
    <li><p>Participate in subsequent design discussions. When there are two or more mature
    implementations, it may be time to extend the feature to address the nice to have use cases (but
@@ -216,7 +223,7 @@
   <h4 id="living-standard">What does “Living Standard” mean?<a class="self-link" href="#living-standard"></a></h4>
 
   <p>The WHATWG standards are described as Living Standards. This means that they are standards
-  that are continuously updated as they receive feedback, either from web designers, browser
+  that are continuously updated as they receive feedback, either from web developers, browser
   vendors, tool vendors, or indeed any other interested party. It also means that new features get
   added to them over time, at a rate intended to keep the standard a little ahead of the
   implementations, but not so far ahead that the implementations give up.


### PR DESCRIPTION
In particular:

* Point out more clearly we're about standards and tests.
* Point to Working Mode.
* Stop pointing to the mailing list.
* Stop using the word "spec".