### PR TITLE
Point to the source of the common deploy.sh script

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -3,7 +3,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# See ./README.md for documentation.
+# This script is maintained at
+# https://github.com/whatwg/whatwg.org/tree/master/resources.whatwg.org/build.
+# See README.md for documentation.
 
 SHORTNAME=$(git config --local remote.origin.url | sed -n "s#.*/\([^.]*\)\.git#\1#p")
 INPUT_FILE=$(find . -maxdepth 1 -name "*.bs" -print -quit)


### PR DESCRIPTION
It's not obvious to look for it in the whatwg.org repo.