### PR TITLE
Replace a YouTube <embed> with <iframe>

### DIFF
--- a/whatwg.org/demos/2008-sept/index
+++ b/whatwg.org/demos/2008-sept/index
@@ -20,7 +20,7 @@
    <li><a href="/mailing-list">Mailing List</a></li>
   </ul>
   <h2>HTML 5 demos from September 2008</h2>
-  <p><embed src="http://www.youtube.com/v/xIxDJof7xxQ&hl=en&fs=1" type="application/x-shockwave-flash" allowfullscreen="true" width="425" height="344"></embed></p>
+  <p><iframe width="560" height="315" src="https://www.youtube.com/embed/xIxDJof7xxQ" frameborder="0" allowfullscreen></iframe></p>
   <p>The demos and segments of this talk are:</p>
   <ol>
    <li> <a href="video/video.html"><code>&lt;video></code></a> (00:35)


### PR DESCRIPTION
The embed snipped suggested by YouTube is used verbatim.