### PR TITLE
Add trailing slashes to multipage redirects

### DIFF
--- a/whatwg.org/.htaccess
+++ b/whatwg.org/.htaccess
@@ -47,10 +47,10 @@ redirect 302 /principles https://whatwg.org/position-paper
 redirect 301 /position-paper https://www.w3.org/2004/04/webapps-cdf-ws/papers/opera.html
 redirect 301 /current-work https://spec.whatwg.org/
 
-redirect 301 /html https://html.spec.whatwg.org/multipage
-redirect 301 /HTML https://html.spec.whatwg.org/multipage
-redirect 301 /html5 https://html.spec.whatwg.org/multipage
-redirect 301 /HTML5 https://html.spec.whatwg.org/multipage
+redirect 301 /html https://html.spec.whatwg.org/multipage/
+redirect 301 /HTML https://html.spec.whatwg.org/multipage/
+redirect 301 /html5 https://html.spec.whatwg.org/multipage/
+redirect 301 /HTML5 https://html.spec.whatwg.org/multipage/
 redirect 301 /wf2 https://html.spec.whatwg.org/multipage/#forms
 redirect 301 /ww https://html.spec.whatwg.org/multipage/#workers
 redirect 301 /ws https://html.spec.whatwg.org/multipage/#network


### PR DESCRIPTION
https://html.spec.whatwg.org/multipage redirects to https://html.spec.whatwg.org/multipage/