### PR TITLE
Fix the styling of https://spec.whatwg.org/

### DIFF
--- a/spec.whatwg.org/index.html
+++ b/spec.whatwg.org/index.html
@@ -14,7 +14,7 @@
   </h1>
   <ul class="navigation">
    <li><a href="https://whatwg.org/" rel="home">Home</a></li>
-   <li class="this">Standards</li>
+   <li class="this"><strong>Standards</strong></li>
    <li><a href="https://whatwg.org/faq">FAQ</a></li>
    <li><a href="https://whatwg.org/policies">Policies</a></li>
    <li><a href="https://participate.whatwg.org/">Participate</a></li>


### PR DESCRIPTION
The <strong> appears to be needed.