### PR TITLE
Manually fix a few Markdown->HTML conversion errors

### DIFF
--- a/whatwg.org/sg-agreement
+++ b/whatwg.org/sg-agreement
@@ -26,13 +26,13 @@
 participation in and governance of the WHATWG. Each party to this <a href="sg-agreement">Agreement</a> is a
 "<dfn id="steering-group-member">Steering Group Member</dfn>"; collectively, the <a href="sg-agreement#steering-group-member">Steering Group Members</a> constitute the "<a href="sg-agreement#steering-group">Steering Group</a>" of
 the WHATWG. Each <a href="sg-agreement#steering-group-member">Steering Group Member</a> and its Affiliates are deemed a single entity under this
-<a href="e.g., for purposes of membership, participation, voting, and intellectual property
-commitments">Agreement</a>.</p>
+<a href="sg-agreement">Agreement</a> (e.g., for purposes of membership, participation, voting, and intellectual property
+commitments).</p>
 <h3 id="2-purpose-of-the-steering-group">2. Purpose of the Steering Group<a class="self-link" href="#2-purpose-of-the-steering-group"></a></h3>
 
 <p>The purpose of the <a href="sg-agreement#steering-group">Steering Group</a> is to govern and guide the WHATWG, an open, efficient forum for
-development of <a href="useful technical specifications, with intellectual property
-commitments from contributors">Living Standards</a> plus associated documentation, code, and other
+development of <a href="workstream-policy#living-standard">Living Standards</a> (useful technical specifications, with intellectual property
+commitments from contributors) plus associated documentation, code, and other
 materials and activities that relate to or support web technologies, as determined by the Steering
 Group.</p>
 <h3 id="3-roles-and-participation">3. Roles and participation<a class="self-link" href="#3-roles-and-participation"></a></h3>
@@ -150,8 +150,8 @@ voting or other rights).</p>
 so long as (1) proposed actions are clear and visible, (2) participants have opportunities to
 voice concerns, and (3) there is no sustained, substantive opposition, then <a href="sg-agreement#consensus">Consensus</a> may be
 established simply by moving forward on the proposal or a course of action; this is anticipated
-to be the norm for most matters. Upon request by a <a href="or upon appeal by a
-party authorized by a WHATWG policy to do so">Steering Group Member</a>, however, a vote must be taken, in which case an
+to be the norm for most matters. Upon request by a <a href="sg-agreement#steering-group-member">Steering Group Member</a> (or upon appeal by a
+party authorized by a WHATWG policy to do so), however, a vote must be taken, in which case an
 affirmative vote of a <a href="sg-agreement#supermajority">Supermajority</a> of <a href="#qualified-voting-party">Qualified Voting Parties</a> establishes <a href="sg-agreement#consensus">Consensus</a>.</p>
 </li>
 <li>


### PR DESCRIPTION
Should be fixed in the conversion script, of course, later.