### PR TITLE
Fix Markdown conversion script to avoid creating bogus links

### DIFF
--- a/convert-policy.py
+++ b/convert-policy.py
@@ -69,12 +69,17 @@ def fix_nested_lists(policy_markdown):
     return re.sub(r'^   1[.]', '    1.', policy_markdown, flags=re.MULTILINE)
 
 
+def avoid_link_false_positives(policy_markdown):
+    return re.sub(r'[]] [(]', '] \\(', policy_markdown)
+
+
 def preprocess_markdown(policy_markdown, link_mapping):
     result = lower_headers(policy_markdown)
     result = apply_link_mapping(result, link_mapping)
     result = add_header_anchors(result)
     result = rewrite_defs(result)
     result = fix_nested_lists(result)
+    result = avoid_link_false_positives(result)
 
     return result
 

--- a/whatwg.org/sg-agreement
+++ b/whatwg.org/sg-agreement
@@ -198,7 +198,7 @@ this <a href="sg-agreement">Agreement</a> on behalf of the identified <a href="s
 <h4 id="mozilla-corporation">Mozilla Corporation<a class="self-link" href="#mozilla-corporation"></a></h4>
 
 <table>
- <tr><th>Signature<td>
+ <tr><th>Signature<td>Mark Mayo
  <tr><th>Name<td>Mark Mayo
  <tr><th>Title<td>SVP Firefox
  <tr><th>Date<td>Nov 30, 2017
@@ -207,7 +207,7 @@ this <a href="sg-agreement">Agreement</a> on behalf of the identified <a href="s
 <h4 id="microsoft-corporation">Microsoft Corporation<a class="self-link" href="#microsoft-corporation"></a></h4>
 
 <table>
- <tr><th>Signature<td>
+ <tr><th>Signature<td>Jason Weber
  <tr><th>Name<td>Jason Weber
  <tr><th>Title<td>Director, Web Platform
  <tr><th>Date<td>Nov 30, 2017
@@ -216,7 +216,7 @@ this <a href="sg-agreement">Agreement</a> on behalf of the identified <a href="s
 <h4 id="google-llc">Google LLC<a class="self-link" href="#google-llc"></a></h4>
 
 <table>
- <tr><th>Signature<td>
+ <tr><th>Signature<td>BMGoodger
  <tr><th>Name<td>BMGoodger
  <tr><th>Title<td>Distinguished Engineer
  <tr><th>Date<td>Nov 30, 2017
@@ -225,7 +225,7 @@ this <a href="sg-agreement">Agreement</a> on behalf of the identified <a href="s
 <h4 id="apple-inc">Apple Inc.<a class="self-link" href="#apple-inc"></a></h4>
 
 <table>
- <tr><th>Signature<td>
+ <tr><th>Signature<td>Darin Adler
  <tr><th>Name<td>Darin Adler
  <tr><th>Title<td>Senior Director, Internet Technologies
  <tr><th>Date<td>Dec 1, 2017

--- a/whatwg.org/workstream-policy
+++ b/whatwg.org/workstream-policy
@@ -186,7 +186,7 @@ or more deputy editors authorized to modify the text on behalf of the
 <ol>
 <li>The <a href="sg-agreement#steering-group">Steering Group</a> may reclassify <a href="workstream-policy#living-standard">Living Standards</a>, including but not limited to the following:<ol>
 <li>No further development by the WHATWG ("<a href="workstream-policy#inanimate-standards">Inanimate</a>" or other designation of the <a href="sg-agreement#steering-group">Steering Group</a>).</li>
-<li>No longer published as a WHATWG <a href="" title="Depublished">Living Standard</a>.</li>
+<li>No longer published as a WHATWG <a href="workstream-policy#living-standard">Living Standard</a> ("Depublished").</li>
 </ol>
 </li>
 </ol>


### PR DESCRIPTION
Fixes #45
Regenerate HTML versions of policy documents with the fixed script.
