### PR TITLE
Keep the margin on <p>s inside notes

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -158,8 +158,6 @@ dl.domintro::before { content: 'Note'; background: green; color: white; padding:
 .note { position: relative; color: green; background: #DDFFDD; font-style: italic; margin-left: 2em; padding-left: 2em; }
 .note em, .note i, .note var { font-style: normal; }
 span.note { padding: 0 2em; }
-.note p:first-child { margin-top: 0; }
-.note p:last-child { margin-bottom: 0; }
 dd > .note:first-child { margin-bottom: 0; }
 .note::before { content: 'Note'; background: green; color: white; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.2em; left: -1.5em; transform: rotate(-5deg); }
 


### PR DESCRIPTION
Before: ![](https://screenshots.firefoxusercontent.com/images/b4eba0a5-dd83-472f-8787-9be8af64a447.png) after: ![](https://screenshots.firefoxusercontent.com/images/a8fbcb85-9fcd-45a0-8040-de389a2d7456.png)