### PR TITLE
Remove obsolete code from convert-policy.py

### DIFF
--- a/convert-policy.py
+++ b/convert-policy.py
@@ -88,7 +88,6 @@ def markdown_title(policy_markdown):
     for line in policy_markdown.split('\n'):
         if line.startswith("#"):
             title = line.lstrip("# ")
-            tile = "WHATWG " + title if "WHATWG" not in title else title
             replacement_line = re.sub(r'^# WHATWG ', '# ', line)
             policy_markdown = policy_markdown.replace(line, replacement_line)
 


### PR DESCRIPTION
This doesn't do anything due to a typo, but is also no longer needed as the titles are now consistent upstream (whatwg/sg).