### PR TITLE
Do not transform text in .category-list

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -203,8 +203,6 @@ hgroup h2, h1 + h2, hr + h2.no-toc { page-break-before: auto ! important; }
 .category-list::before { content: '\21D2\A0'; font-size: 1.2em; font-weight: 900; }
 .category-list li { display: inline; }
 .category-list li:not(:last-child)::after { content: ', '; }
-.category-list li > span, .category-list li > a { text-transform: lowercase; }
-.category-list li * { text-transform: none; } /* don't affect <code> nested in <a> */
 
 .big-issue, .XXX { color: #E50000; background: white; border: solid red; padding: 0.5em; margin: 1em 0; }
 .big-issue > :first-child, .XXX > :first-child { margin-top: 0; }


### PR DESCRIPTION
As far as I know this only affects the HTML Standard.

This makes "MathML math" appear as "mathml math". And "Hidden state" as "hidden state", despite everywhere else using the former. The only somewhat intentional lowercase might be "Text", but we should just lowercase that in the source in that case.