### PR TITLE
Fix logic for computing the title of policies

### DIFF
--- a/convert-policy.py
+++ b/convert-policy.py
@@ -87,7 +87,7 @@ def preprocess_markdown(policy_markdown, link_mapping):
 def markdown_title(policy_markdown):
     for line in policy_markdown.split('\n'):
         if line.startswith("# WHATWG "):
-            title = line.lstrip("# WHATWG ")
+            title = line[len("# WHATWG "):]
             policy_markdown = policy_markdown.replace(line, "")
 
             return (title, policy_markdown)


### PR DESCRIPTION
It turns out lstrip does not do what I thought it did. Fixes the "orkstream Policy" title.

This bug was introduced in 4d34512aeb618c8753e317b220a7937c2161fb11. Thanks @michaelchampion for spotting!