### PR TITLE
Make padding consistent for Note and Example sections

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -155,7 +155,7 @@ dl.domintro dd { margin: 0.5em 0 1em 2em; padding: 0; }
 dl.domintro dd p { margin: 0.5em 0; }
 dl.domintro::before { content: 'For web developers (non-normative)'; background: green; color: white; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.8em; left: -0.8em; }
 
-.note { position: relative; color: green; background: #DDFFDD; font-style: italic; margin-left: 2em; padding-left: 2em; }
+.note { position: relative; color: green; background: #DDFFDD; font-style: italic; margin-left: 2em; padding: 0.5em 1em 0.5em 2em; }
 .note em, .note i, .note var { font-style: normal; }
 span.note { padding: 0 2em; }
 dd > .note:first-child { margin-bottom: 0; }
@@ -167,8 +167,10 @@ dd > .note:first-child { margin-bottom: 0; }
 .warning p:last-child { margin-bottom: 0; }
 .warning::before { font-style: normal; content: '\26A0 Warning!'; background: red; color: yellow; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.2em; left: -4.25em; transform: rotate(-5deg); }
 
-.example { display: block; color: #222222; background: #EEEEEE; margin-left: 2em; padding-left: 3em; position: relative; }
+.example { display: block; color: #222222; background: #EEEEEE; margin-left: 2em; padding: 0.5em 1em 0.5em 3em; position: relative; }
 .example::before { font-style: normal; content: 'Example'; background: #222222; color: #EEEEEE; padding: 0.15em 0.25em; font: 1em Helvetica Neue, sans-serif, Droid Sans Fallback; position: absolute; top: 0.2em; left: -2.25em; transform: rotate(-5deg); }
+.example p:first-child { margin-top: 0; }
+.example p:last-child { margin-bottom: 0; }
 td > .example:only-child { margin: 0 0 0 0.1em; padding: 0; }
 td > .example:only-child::before { display: none; }
 /* Nudge bikeshed's self-link */


### PR DESCRIPTION
This is just a quick fix to the padding issue for the Note and Example sections.

I chose not to use CSS variables here because:

- I'm not sure how many people still view WHATWG specs with older browsers. Don't want to break anyone's setup with a trivial change.
- Just having a few variables would be inconsistent IMO. A rewrite is better here.

The stylesheet could be a lot more organized and tidy (more comments, line breaks, etc.), but that's another issue.

Fixes #187.

<details><summary>Screenshots</summary>
<br>
Before:
<img src="https://i.imgur.com/3AAIfKj.jpg">
<br>
After:
<img src="https://i.imgur.com/kgfXUcL.jpg">
<br>
Before:
<img src="https://i.imgur.com/Va0QbBg.jpg">
<br>
After:
<img src="https://i.imgur.com/TyLMlZN.jpg">
</details>