### PR TITLE
Move IRC wiki page to whatwg.org

### DIFF
--- a/whatwg.org/faq
+++ b/whatwg.org/faq
@@ -65,8 +65,7 @@ Our existing work can be seen on the <a href="https://spec.whatwg.org/">standard
 list of
 <a href="https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+bug%22+user%3Awhatwg">good
 first bugs</a> on GitHub, if you're interested in helping us editing the standards directly. Also,
-feel free to stop in to <a href="https://wiki.whatwg.org/wiki/IRC">IRC</a> and ask questions of
-other community members.
+feel free to stop in to <a href="/irc">IRC</a> and ask questions of other community members.
 
 <p>For more information, see our dedicated site at
 <a href="https://participate.whatwg.org/">participate.whatwg.org</a>. Additionally,
@@ -145,9 +144,8 @@ welcome to take a stab at addressing the problem yourself through a GitHub pull 
 <p>If you want feedback to be dealt with faster than “eventually”, e.g., because you are about to
 work on that feature and need the standard to be updated to take into account all previous
 feedback, let the editors know by either emailing them, or contacting them on
-<a href="https://wiki.whatwg.org/wiki/IRC">IRC</a>. Requests for priority feedback handling are
-handled confidentially if desired so other implementers won’t know that you are working on that
-feature.
+<a href="/irc">IRC</a>. Requests for priority feedback handling are handled confidentially if
+desired so other implementers won’t know that you are working on that feature.
 
 <h4 id="removing-bad-ideas">Is there a process for removing bad ideas from a standard?<a class="self-link" href="#removing-bad-ideas"></a></h4>
 

--- a/whatwg.org/index.html
+++ b/whatwg.org/index.html
@@ -169,7 +169,7 @@ header > hgroup > h2 {
   <strong>Participate</strong>
   <p>Get started with contributing to the WHATWG</p>
  </a>
- <a href="https://wiki.whatwg.org/wiki/IRC" id="irc">
+ <a href="/irc" id="irc">
   <strong>IRC</strong>
   <p>Chat with other members of the WHATWG community</p>
  </a>

--- a/whatwg.org/irc
+++ b/whatwg.org/irc
@@ -1,0 +1,63 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<meta charset="utf-8">
+<title>IRC — WHATWG</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#3A7908">
+<link rel="icon" href="https://resources.whatwg.org/logo.svg">
+<link rel="stylesheet" href="/style/shared.css">
+<link rel="stylesheet" href="/style/subpages.css">
+
+<header>
+ <hgroup>
+  <h1>
+   <a href="/">
+    <img id="main-logo" src="https://resources.whatwg.org/logo.svg" alt="">
+    WHATWG
+   </a>
+  </h1>
+  <h2>IRC</h2>
+ </hgroup>
+</header>
+
+<nav class="buttonish-links">
+ <a href="https://spec.whatwg.org/">Standards</a>
+ <a href="/faq">FAQ</a>
+ <a href="/policies">Policies</a>
+ <a href="https://participate.whatwg.org/">Participate</a>
+</nav>
+
+<h3 id="irc">IRC<a class="self-link" href="#irc"></a></h3>
+
+<p>The Freenode IRC network has a channel called <a href="ircs://irc.freenode.net/whatwg">#whatwg</a> where some of the more active WHATWG community members hang out. Feel free to join us!</p>
+
+<p>Note that if you go to IRC to ask a question, it might take a while to get a reply. It can pay off to stick around for a couple of hours or more.</p>
+
+<p>If you want to run a bot, let us know. If they are useful, e.g. providing logging facilities, then they are more than welcome.</p>
+
+<h3 id="logs">Logs<a class="self-link" href="#logs"></a></h3>
+
+<p>Logs for the #whatwg channel can be found here:</p>
+
+<ul>
+ <li><a href="https://freenode.logbot.info/whatwg">https://freenode.logbot.info/whatwg</a></li>
+ <li><a href="https://krijnhoetmer.nl/irc-logs/">https://krijnhoetmer.nl/irc-logs/</a> (not updated since 2016-04)</li>
+</ul>
+
+<h3 id="bots">Bots<a class="self-link" href="#bots"></a></h3>
+
+<p>To leave a message to someone who is offline you can do:</p>
+
+<pre>
+   botie, inform <nick> [that|to|about] &lt;message&gt;
+</pre>
+
+<p>Source/docs for botie is at <a href="https://github.com/w3c/infobot">https://github.com/w3c/infobot</a></p>
+
+<h3 id="getting-started-with-irc">Getting Started with IRC<a class="self-link" href="#getting-started-with-irc"></a></h3>
+
+<p>The simplest way to get started with IRC, if you are not familiar, is by signing up for a free <a href="https://www.irccloud.com/">IRCCloud</a> account. Once you've done that, you should be logged in to the Freenode server by default. All you'll have to do is join the #whatwg channel. If you tell your browser to use IRCCloud for irc:// links, then just <a href="ircs://irc.freenode.net/whatwg">clicking this link</a> should also take you there.</p>
+
+<footer>
+ <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>
+</footer>


### PR DESCRIPTION
Hope I'm doing this right.

This is a direct copy of the IRC wiki page, but with one exception: I changed `irc://` to `ircs://` and added a colon before the `pre` block.

Ref #162