### PR TITLE
Move Style wiki page to whatwg.org

### DIFF
--- a/whatwg.org/style-guide
+++ b/whatwg.org/style-guide
@@ -1,0 +1,91 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<meta charset="utf-8">
+<title>Style Guide — WHATWG</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="theme-color" content="#3A7908">
+<link rel="icon" href="https://resources.whatwg.org/logo.svg">
+<link rel="stylesheet" href="/style/shared.css">
+<link rel="stylesheet" href="/style/subpages.css">
+
+<header>
+ <hgroup>
+  <h1>
+   <a href="/">
+    <img id="main-logo" src="https://resources.whatwg.org/logo.svg" alt="">
+    WHATWG
+   </a>
+  </h1>
+  <h2>Style Guide</h2>
+ </hgroup>
+</header>
+
+<nav class="buttonish-links">
+ <a href="https://spec.whatwg.org/">Standards</a>
+ <a href="/faq">FAQ</a>
+ <a href="/policies">Policies</a>
+ <a href="https://participate.whatwg.org/">Participate</a>
+</nav>
+
+<h3 id="language">Language<a class="self-link" href="#language"></a></h3>
+
+<p>American English.</p>
+
+<h3 id="dictionary">Dictionary<a class="self-link" href="#dictionary"></a></h3>
+
+<ul>
+ <li>behavior</li>
+ <li>bitrate</li>
+ <li>built-in (though see <a href="https://github.com/heycam/webidl/issues/350">https://github.com/heycam/webidl/issues/350</a>)</li>
+ <li>cancelation</li>
+ <li>canceled</li>
+ <li>canceling</li>
+ <li>cipher</li>
+ <li>colorspace</li>
+ <li>email</li>
+ <li>implementer</li>
+ <li>keepalive (though HTTP Keep-Alive [sic] header)</li>
+ <li>metadata</li>
+ <li>nonzero</li>
+ <li>referrer (though HTTP Referer [sic] header)</li>
+ <li>whitespace (though CSS white-space [sic] property)</li>
+</ul>
+
+<h3 id="grammar">Grammar<a class="self-link" href="#grammar"></a></h3>
+
+<ul>
+ <li>Use 's for possessives, even when it looks unnatural.</li>
+ <li>Use the <a href="https://en.wikipedia.org/wiki/Serial_comma">Oxford Comma</a>.</li>
+ <li>Avoid "one of" unless it's followed by a bulleted list. You can normally leave it out and just use "or". If you cannot leave it out, that might be a good indication you want to use a bulleted list for clarity.</li>
+ <li>A hierarchy (not an).</li>
+</ul>
+
+<h3 id="casing">Casing<a class="self-link" href="#casing"></a></h3>
+
+<ul>
+ <li>web, unless at the start of a sentence</li>
+</ul>
+
+<h3 id="punctuation">Punctuation<a class="self-link" href="#punctuation"></a></h3>
+
+<ul>
+ <li>Spaces around — (em dash)</li>
+ <li>Lowercase after colon (<em>The slot attribute is used to assign a slot to an element: an element with a slot attribute is assigned to the slot created by the slot element whose name attribute's value matches that slot attribute's value</em>)</li>
+</ul>
+
+<h3 id="words-and-phrases-used-as-words">Words and phrases used as words<a class="self-link" href="#words-and-phrases-used-as-words"></a></h3>
+
+<ul>
+ <li>When a word or term is not used functionally but is referred to as the word or term itself, enclose it in quotation marks. (See also: <a href="http://www.chicagomanualofstyle.org/qanda/data/faq/topics/NoneoftheAbove/faq0012.html">some examples that highlight why this is necessary</a>.)</li>
+</ul>
+
+<h3 id="tone">Tone<a class="self-link" href="#tone"></a></h3>
+
+<ul>
+ <li>Avoid using "simply" or suggesting that something is simple</li>
+ <li>Don't use "white" as meaning good and "black" as meaning bad; more concretely, "safelist" and "blocklist" are established precedent</li>
+</ul>
+
+<footer>
+ <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>
+</footer>


### PR DESCRIPTION
This commit adds the Style wiki page to whatwg.org. Since `style` is already a directory, I opted to go with `style-guide` instead. (I also believe that "Style Guide" is the better title here.)

This is a direct copy of the style page. I think it's best to improve the page with separate issues / pull requests. Fixed a typo for "possessives". Besides that, nothing else should have changed.

Ref #162