### PR TITLE
 Fix old Code of Conduct link

### DIFF
--- a/whatwg.org/working-mode
+++ b/whatwg.org/working-mode
@@ -29,7 +29,7 @@
 
 <p>The WHATWG develops standards and assists in maintaining their corresponding tests, thereby
 fostering independent implementations. The WHATWG adheres to a shared
-<a href="https://wiki.whatwg.org/wiki/Code_of_Conduct">Code of Conduct</a>.
+<a href="/code-of-conduct">Code of Conduct</a>.
 
 <p>While discussing and working on standards, it’s always useful to keep these questions in mind:
 


### PR DESCRIPTION
Seems like this was missed somewhere. Only old wiki link I found that hasn't been changed yet.

Related: #34