### PR TITLE
Deduplicate whatwg.org deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,9 @@ whatwg.org/sg-agreement
 whatwg.org/sg-policy
 whatwg.org/workstream-policy
 
+# Not yet covered by the above, but imported from the same repository
+whatwg.org/code-of-conduct
+whatwg.org/working-mode
+
 # Ignore folder used by deploy.sh to prevent using it for something else
 sg/

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,11 +3,7 @@ set -e
 
 echo "Importing content from whatwg/sg and making it suitable for whatwg.org"
 git clone --depth=1 https://github.com/whatwg/sg sg
-./convert-policy.py sg/SG\ Policy.md policy-template.html sg/policy-link-mapping.txt  > whatwg.org/sg-policy
-./convert-policy.py sg/Workstream\ Policy.md policy-template.html sg/policy-link-mapping.txt  > whatwg.org/workstream-policy
-./convert-policy.py sg/SG\ Agreement.md policy-template.html sg/policy-link-mapping.txt  > whatwg.org/sg-agreement
-./convert-policy.py sg/Principles.md policy-template.html sg/policy-link-mapping.txt  > whatwg.org/principles
-./convert-policy.py sg/IPR\ Policy.md policy-template.html sg/policy-link-mapping.txt  > whatwg.org/ipr-policy
+./convert-policy.py
 mv sg/code-of-conduct whatwg.org/code-of-conduct
 mv sg/working-mode whatwg.org/working-mode
 rm -rf sg


### PR DESCRIPTION
Instead extract the mappings from sg/policy-link-mapping.txt directly.

Fixes #173.