### PR TITLE
Code of Conduct is now maintained in Markdown upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ whatwg.org/principles
 whatwg.org/sg-agreement
 whatwg.org/sg-policy
 whatwg.org/workstream-policy
+whatwg.org/code-of-conduct
 
 # Not yet covered by the above, but imported from the same repository
-whatwg.org/code-of-conduct
 whatwg.org/working-mode
 
 # Ignore generated snapshot logos

--- a/deploy.sh
+++ b/deploy.sh
@@ -4,7 +4,6 @@ set -e
 echo "Importing content from whatwg/sg and making it suitable for whatwg.org"
 git clone --depth=1 https://github.com/whatwg/sg sg
 ./convert-policy.py
-mv sg/code-of-conduct whatwg.org/code-of-conduct
 mv sg/working-mode whatwg.org/working-mode
 rm -rf sg
 echo "Markdown converted to HTML"


### PR DESCRIPTION
See https://github.com/whatwg/sg/pull/79.