### PR TITLE
Update syntax highlighting styles

### DIFF
--- a/resources.whatwg.org/spec.css
+++ b/resources.whatwg.org/spec.css
@@ -2,9 +2,8 @@
 
 .toc, .toc li { list-style: none; }
 
-pre.idl::before { content: 'IDL'; }
-pre.asn::before { content: 'ASN'; }
-pre.css::before { content: 'CSS'; }
+pre > code.idl::before, pre.idl::before { content: 'IDL'; }
+pre > code.css::before, pre.highlight.lang-css::before { content: 'CSS'; }
 
 .note::before { content: 'Note'; }
 .warning::before { content: '\26A0 Warning!'; }

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -18,7 +18,7 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
   :link { color: #00C; }
   :visited { color: #609; }
   :link:active, :visited:active { color: #C00; }
-  pre :link, pre :visited { color: inherit; background: transparent; text-decoration: none; }
+  pre :link, pre :visited { background: transparent; text-decoration: none; }
   pre:hover :link, pre:hover :visited { text-decoration: underline; }
 }
 
@@ -46,6 +46,7 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
 code { color: #666666; }
 dfn code { color: orangered; }
 code :link, :link code, code :visited, :visited code { color: orangered; }
+pre :link, pre :visited { color: inherit; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h1, h2, h3, h4, h5, h6 { text-align: left; text-rendering: optimizeLegibility; }
@@ -64,7 +65,6 @@ h1 + h2, h2 + h3, h3 + h4, h4 + h5, h5 + h6, h1 + div.status + h2, h2 + div.stat
 header + h2, header + hr + h2, header + hr + #configUI + h2, header + hr + #configUI + #updatesStatus + h2, h2.no-toc { margin-top: 2em; }
 hr { display: block; background: none; border: none; padding: 0; margin: 3em 0; height: auto; }
 p { margin: 1.25em 0; }
-pre { margin-left: 2em; white-space: pre-wrap; }
 dl, dd { margin-top: 0; margin-bottom: 0; }
 dt { margin-top: 0.75em; margin-bottom: 0.25em; clear: left; }
 dt ul { margin: 0 1.25em; }
@@ -146,7 +146,7 @@ body > .toc > li > * > li > * > li > * > li { margin-top: 0.1em; margin-bottom: 
 dt, dfn { font-weight: bolder; font-style: normal; }
 i, em, dt dfn { font-style: italic; }
 pre, code { font-size: inherit; font-family: monospace, Droid Sans Fallback, Helvetica Neue, sans-serif; font-variant: normal; }
-pre strong { color: black; font: inherit; background: #DDFFDD; color: green; }
+pre strong { font: inherit; background: #DDFFDD; color: green; }
 pre small { color: silver; font: inherit; }
 pre em { font-weight: bolder; font-style: normal; }
 var sub { vertical-align: bottom; font-size: smaller; top: 0.1em; }
@@ -177,16 +177,6 @@ dl.triple dt, dl.triple dd { margin: 0; display: inline }
 dl.triple dt:after { content: ':'; }
 dl.triple dd:after { content: '\A'; white-space: pre; }
 tr.rare { background: #EEEEEE; color: #333333; }
-
-pre.idl::before, pre.asn::before, pre.css::before { font: bold 0.8rem Helvetica Neue, sans-serif; padding: 0.5em; position: absolute; top: auto; margin: -0.703125em 0 0 -3.75em /* 1em/0.8 + 1.5em + 0.5em*2 */ ; width: 1.5em; background: inherit; border: 0.078125em; border-style: solid none solid solid; border-radius: 1em 0 0 1em; }
-pre.idl { border: solid 0.0625em; background: #EEEEEE; color: black; padding: 0.5em 1em; }
-pre.asn { border: solid 0.0625em; background: #EEEEEE; color: black; padding: 0.5em 1em; }
-pre.css { border: solid 0.0625em; background: #FFFFEE; color: black; padding: 0.5em 1em; }
-pre.css:first-line { color: #AAAA50; }
-@media (max-width: 767px) {
-  pre.idl, pre.css { padding-left: 0.33em; }
-  pre.idl::before, pre.css::before { width: 2.3em; }
-}
 
 dl.domintro { position: relative; color: green; background: #DDFFDD; margin: 2.5em 0 2em 0; padding: 0.5em 1em 0.5em 2em; }
 hr + dl.domintro, div.impl + dl.domintro, hr + div.status + dl.domintro, div.impl + div.status + dl.domintro { margin-top: 2.5em; margin-bottom: 1.5em; }
@@ -411,10 +401,62 @@ ul.domTree .t7 code, .domTree .t8 code { color: green; }
 ul.domTree .t10 code { color: teal; }
 ul.domTree code :link, ul.domTree code :visited { color: inherit; }
 
+/* Note: Bikeshed uses pre.highlight/pre.idl; HTML uses pre > code */
+/* Some <pre>s are not highlighted, e.g. output listings */
+
+pre {
+  margin: 0.5em 2em;
+  white-space: pre-wrap;
+}
+
+pre > code, pre.highlight, pre.idl {
+  display: block;
+  padding: 0.5em 1em;
+  overflow: auto;
+  border-radius: 0.3em;
+  background: hsl(24, 20%, 95%);
+}
+
+pre > code.idl, pre.idl, pre > code.css, pre.highlight.lang-css {
+  border: solid 0.0625em;
+  color: black;
+  border-top-left-radius: 0;
+}
+
+pre > code.idl::before, pre.idl::before, pre > code.css::before, pre.highlight.lang-css::before {
+  font: bold 0.8rem Helvetica Nue, sans-serif;
+  padding: 0.5em;
+  position: absolute;
+  top: auto;
+  margin: -0.703125em 0 0 -3.75em /* 1em/0.8 + 1.5em + 0.5em*2 */;
+  width: 1.5em;
+  background: inherit;
+  border: 0.078125em;
+  border-style: solid none solid solid;
+  border-radius: 1em 0 0 1em;
+}
+
+pre > code.idl, pre.idl {
+  background: #EEE;
+}
+
+pre > code.css, pre.highlight.lang-css {
+  background: #FFE;
+}
+pre > code.css::first-line { /* Special HTML-specific rule for UA stylesheet @namespace lines */
+  color: #AAAA50;
+}
+
+@media (max-width: 767px) {
+  pre > code.idl, pre.idl, pre > code.css, pre.highlight.lang-css {
+    padding-left: 0.33em;
+  }
+  pre > code.idl::before, pre.idl::before, pre > code.css::before, pre.highlight.lang-css::before {
+    width: 2.3em;
+  }
+}
+
 /* for output from https://github.com/tabatkins/highlighter */
-.highlight:not(.idl) { background: hsl(24, 20%, 95%); }
-code.highlight { padding: .1em; border-radius: .3em; }
-pre.highlight, pre > code.highlight { display: block; padding: 1em; margin: .5em 0; overflow: auto; border-radius: 0; }
 c-[a] { color: #990055 } /* Keyword.Declaration */
 c-[b] { color: #990055 } /* Keyword.Type */
 c-[c] { color: #708090 } /* Comment */


### PR DESCRIPTION
The main purpose of this commit is to adapt to the new markup style in https://github.com/whatwg/html/pull/3768. This also fixes minor inconsistencies and redundancies noted throughout the stylesheet for pre elements. (Most notably, it will treat Bikeshed-produced IDL and CSS blocks the same as those in HTML.) And it removes special treatment of the "asn" class, which does not appear in any current specs.

/cc @Zirro @sideshowbarker.

We should merge this and https://github.com/whatwg/html/pull/3768 at roughly the same time.