### PR TITLE
Small fix to service worker error handling

### DIFF
--- a/resources.whatwg.org/standard-service-worker.js
+++ b/resources.whatwg.org/standard-service-worker.js
@@ -70,7 +70,7 @@ self.onactivate = e => {
 
 function refreshCacheFromNetworkResponse(req, res) {
   if (res.type !== "opaque" && !res.ok) {
-    throw new Error(`${res.url} is responding with ${res.status}`);
+    return Promise.reject(new Error(`${res.url} is responding with ${res.status}`));
   }
 
   const resForCache = res.clone();

--- a/resources.whatwg.org/website-service-worker.js
+++ b/resources.whatwg.org/website-service-worker.js
@@ -55,7 +55,7 @@ self.onfetch = e => {
 
 function refreshCacheFromNetworkResponse(req, res) {
   if (res.type !== "opaque" && !res.ok) {
-    throw new Error(`${res.url} is responding with ${res.status}`);
+    return Promise.reject(new Error(`${res.url} is responding with ${res.status}`));
   }
 
   const resForCache = res.clone();


### PR DESCRIPTION
Before this, navigating to a page that gives a non-OK status for a living standard (e.g. https://streams.spec.whatwg.org/asdf) would cause the code to go down a path of trying to get the result from the cache. Since the cache would contain no entries for such pages, this would end up calling fetchEvent.respondWith(null). The result is a network error, giving a scary error page in various browers (e.g. "Corrupted Content Error" in Firefox).

After this page, the non-OK status only impacts the waitUntil() call, as intended.