### PR TITLE
Output Bikeshed errors if they occur

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -65,11 +65,25 @@ header() {
 }
 
 curlretry() {
-    curl --fail --retry 2 "$@"
+    curl --retry 2 "$@"
 }
 
 curlbikeshed() {
-    curlretry https://api.csswg.org/bikeshed/ -F die-on=warning -F file=@"$INPUT_FILE" "$@"
+    # The Accept: header ensures we get the error output even when warnings are produced, per
+    # https://github.com/whatwg/whatwg.org/issues/227#issuecomment-419969339.
+    HTTP_STATUS=$(curlretry https://api.csswg.org/bikeshed/ \
+                            --output "$1" \
+                            --write-out "%{http_code}" \
+                            --header "Accept: text/plain, text/html" \
+                            -F die-on=warning \
+                            -F file=@"$INPUT_FILE" \
+                            "${@:2}")
+
+    if [[ "$HTTP_STATUS" != "200" ]]; then
+        cat "$1"
+        rm -f "$1"
+        exit 22
+    fi
 }
 
 header "Linting the source:"
@@ -87,26 +101,22 @@ else
 fi
 echo ""
 
-header "Checking for errors and warnings using Bikeshed..."
-curlbikeshed -F output=err -F md-Text-Macro="SNAPSHOT-LINK ERROR WARNING CHECK"
-echo ""
-
 header "Starting commit snapshot..."
 COMMIT_DIR="$WEB_ROOT/$COMMITS_DIR/$SHA"
 mkdir -p "$COMMIT_DIR"
-curlbikeshed -F md-status=LS-COMMIT \
+curlbikeshed "$COMMIT_DIR/index.html" \
+             -F md-status=LS-COMMIT \
              -F md-warning="Commit $SHA $COMMIT_URL_BASE$SHA replaced by $LS_URL" \
              -F md-title="$H1 Standard (Commit Snapshot $SHA)" \
-             -F md-Text-Macro="SNAPSHOT-LINK $BACK_TO_LS_LINK" \
-             > "$COMMIT_DIR/index.html";
+             -F md-Text-Macro="SNAPSHOT-LINK $BACK_TO_LS_LINK"
 copy_extra_files "$COMMIT_DIR"
 run_post_build_step "$COMMIT_DIR"
 echo "Commit snapshot output to $COMMIT_DIR"
 echo ""
 
 header "Starting living standard..."
-curlbikeshed -F md-Text-Macro="SNAPSHOT-LINK $SNAPSHOT_LINK" \
-             > "$WEB_ROOT/index.html";
+curlbikeshed "$WEB_ROOT/index.html" \
+             -F md-Text-Macro="SNAPSHOT-LINK $SNAPSHOT_LINK"
 copy_extra_files "$WEB_ROOT"
 run_post_build_step "$WEB_ROOT"
 echo "Living standard output to $WEB_ROOT"
@@ -127,8 +137,8 @@ for CHANGED in $CHANGED_FILES; do # Omit quotes around variable to split on whit
     BASENAME=$(basename "$CHANGED" .bs)
     DRAFT_DIR="$WEB_ROOT/$REVIEW_DRAFTS_DIR/$BASENAME"
     mkdir -p "$DRAFT_DIR"
-    curlbikeshed -F md-Status="RD" \
-                 > "$DRAFT_DIR/index.html"
+    curlbikeshed "$DRAFT_DIR/index.html" \
+                 -F md-Status="RD"
     copy_extra_files "$DRAFT_DIR"
     run_post_build_step "$DRAFT_DIR"
     echo "Review draft output to $DRAFT_DIR"
@@ -137,7 +147,7 @@ echo ""
 
 # Standard service worker and robots.txt
 header "Getting the service worker hash..."
-SERVICE_WORKER_SHA=$(curlretry https://resources.whatwg.org/standard-service-worker.js | shasum | cut -c 1-40)
+SERVICE_WORKER_SHA=$(curlretry --fail https://resources.whatwg.org/standard-service-worker.js | shasum | cut -c 1-40)
 
 EXTRA_FILES_JS=""
 if [[ "$EXTRA_FILES" != "" ]]; then
@@ -169,7 +179,7 @@ echo ""
 # Run the HTML checker only when building on Travis
 if [[ "$TRAVIS" == "true" ]]; then
     header "Running the HTML checker..."
-    curl -O https://sideshowbarker.net/nightlies/jar/vnu.jar
+    curlretry --fail --remote-name https://sideshowbarker.net/nightlies/jar/vnu.jar
     /usr/lib/jvm/java-8-oracle/jre/bin/java -jar vnu.jar --skip-non-html --Werror --filterpattern "$CHECKER_FILTER" "$WEB_ROOT"
     echo ""
 fi


### PR DESCRIPTION
This is a revision of fdf8cedf0ddc45af217f192d2e967249478b460a which should work correctly. It uses the Accept header to get the right output. It also fixes a bug with that commit where we accidentally passed through the output filename twice. And, it generally tidies up some curl usage in the rest of the script.

Closes #227. Closes #223.