### PR TITLE
Fix Markdown compilation deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - SERVER_PUBLIC_KEY="ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBDt6Igtp73aTOYXuFb8qLtgs80wWF6cNi3/AItpWAMpX3PymUw7stU7Pi+IoBJz21nfgmxaKp3gfSe2DPNt06l8="
 
 install:
-  - pip install markdown py-gfm
+  - pip install markdown==2.6.11 py-gfm==0.1.4
 script:
   - shellcheck deploy.sh
   - shellcheck resources.whatwg.org/build/*.sh


### PR DESCRIPTION
A recent update to the Python Markdown module broke our build, as the py-gfm module we use isn't compatible with markdown 3.x. This pins the versions of our Python modules to avoid such breakage.