### PR TITLE
Remove one over-shared spec style

### DIFF
--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -23,10 +23,6 @@ h2 > a.self-link, h3 > a.self-link, h4 > a.self-link, h5 > a.self-link, h6 > a.s
   border-bottom: none;
 }
 
-h2 > a.self-link {
-  left: -4em;
-}
-
 a.self-link::before {
   content: "¶";
 }


### PR DESCRIPTION
Follows https://github.com/whatwg/html/pull/4130. This style only applies to the dev edition, and should not be shared.