### PR TITLE
Fix HTML checker url

### DIFF
--- a/whatwg.org/index.html
+++ b/whatwg.org/index.html
@@ -177,7 +177,7 @@ header > hgroup > h2 {
   <strong>Twitter</strong>
   <p>Keep track of spec changes and other announcements</p>
  </a>
- <a href="https://checker.html5.org/" id="checker">
+ <a href="https://whatwg.org/validator/" id="checker">
   <strong>HTML checker</strong>
   <p>Validate your HTML documents</p>
  </a>

--- a/whatwg.org/validator/index.html
+++ b/whatwg.org/validator/index.html
@@ -31,12 +31,8 @@
 
 <ul>
  <li>
-  <p><a href="https://html5.validator.nu/">Validator.nu (X)HTML5 Validator</a></p>
-  <form method="get" action="https://html5.validator.nu/"><p><label>Address of page to check: <input type="url" name="doc" pattern="(?:(?:https?://.+)|(?:data:.+))?" title="Absolute URL (http, https or data only) of the document to be checked."></label> <input name="submit" value="Check" type="submit"></p></form>
- </li>
- <li>
-  <p><a href="https://checker.html5.org/">Nu Html Checker</a></p>
-  <form method="get" action="https://checker.html5.org/"><p><label>Address of page to check: <input type="url" name="doc" pattern="(?:(?:https?://.+)|(?:data:.+))?" title="Absolute URL (http, https or data only) of the document to be checked."></label> <input name="submit" value="Check" type="submit"></p></form>
+  <p><a href="https://validator.w3.org/nu/">Nu Html Checker</a></p>
+  <form method="get" action="https://validator.w3.org/nu/"><p><label>Address of page to check: <input type="url" name="doc" pattern="(?:(?:https?://.+)|(?:data:.+))?" title="Absolute URL (http, https or data only) of the document to be checked."></label> <input name="submit" value="Check" type="submit"></p></form>
  </li>
 </ul>
 


### PR DESCRIPTION
I found https://checker.html5.org/ is 502 now. I think it's the `validator`?