### PR TITLE
Uniformize spec paragraph styles

### DIFF
--- a/resources.whatwg.org/standard-new.css
+++ b/resources.whatwg.org/standard-new.css
@@ -294,6 +294,7 @@ td > .example:only-child::before {
   display: none;
 }
 
+
 .XXX {
   color: #E50000;
   background: white;
@@ -304,6 +305,8 @@ td > .example:only-child::before {
   background: #FFFFCC;
   border: double thick red;
 }
+
+
 
 figure.diagrams { border: thin solid black; background: white; padding: 1em; }
 figure.diagrams img { display: block; margin: 1em auto; }

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -172,39 +172,141 @@ dl.triple dt:after { content: ':'; }
 dl.triple dd:after { content: '\A'; white-space: pre; }
 tr.rare { background: #EEEEEE; color: #333333; }
 
-dl.domintro { position: relative; color: green; background: #DDFFDD; margin: 2.5em 0 2em 0; padding: 0.5em 1em 0.5em 2em; }
-hr + dl.domintro, div.impl + dl.domintro, hr + div.status + dl.domintro, div.impl + div.status + dl.domintro { margin-top: 2.5em; margin-bottom: 1.5em; }
-dl.domintro dt, dl.domintro dt * { color: black; }
-dl.domintro dd { margin: 0.5em 0 1em 2em; padding: 0; }
-dl.domintro dd p { margin: 0.5em 0; }
-dl.domintro::before { background: green; color: white; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.8em; left: -0.8em; }
+/*
+ * .domintro, .note, .warning, .example, .XXX, .critical
+ */
 
-.note { position: relative; color: green; background: #DDFFDD; font-style: italic; margin-left: 2em; padding-left: 2em; }
-.note em, .note i, .note var { font-style: normal; }
-span.note { padding: 0 2em; }
-dd > .note:first-child { margin-bottom: 0; }
-.note::before { background: green; color: white; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.2em; left: -1.5em; transform: rotate(-5deg); }
-
-.warning { color: red; background: transparent; font: bolder italic 1em Helvetica Neue, sans-serif, Droid Sans Fallback; position: relative; margin: 2em 0 2em 6em; padding-left: 2em; }
-.warning em, .warning i, .warning var { font-style: normal; }
-.warning p:first-child { margin-top: 0; }
-.warning p:last-child { margin-bottom: 0; }
-.warning::before { font-style: normal; background: red; color: yellow; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.2em; left: -4.25em; transform: rotate(-5deg); }
-
-.example { display: block; color: #222222; background: #EEEEEE; margin-left: 2em; padding-left: 3em; position: relative; }
-.example::before { font-style: normal; background: #222222; color: #EEEEEE; padding: 0.15em 0.25em; font: 1em Helvetica Neue, sans-serif, Droid Sans Fallback; position: absolute; top: 0.2em; left: -2.25em; transform: rotate(-5deg); }
-td > .example:only-child { margin: 0 0 0 0.1em; padding: 0; }
-td > .example:only-child::before { display: none; }
-/* Nudge bikeshed's self-link */
-@media (min-width: 768px) {
-  .example > a.self-link { left:-5em; }
+.domintro, .note, .warning, .example, .XXX, .critical {
+  margin: 2em 0;
+  padding: 0.5em 1em;
+}
+.domintro > :first-child, .note > :first-child, .warning > :first-child, .example > :first-child, .XXX > :first-child, .critical > :first-child,
+.domintro > .self-link:first-child + *, .note > .self-link:first-child + *, .warning > .self-link:first-child + *, .example > .self-link:first-child + *, .XXX > .self-link:first-child + *, .critical > .self-link:first-child + * {
+  margin-top: 0;
+}
+.domintro > :last-child, .note > :last-child, .warning > :last-child, .example > :last-child, .XXX > :last-child, .critical > :last-child {
+  margin-bottom: 0;
 }
 
+/* These ones have decorations */
+.domintro, .note, .warning, .example {
+  position: relative;
+
+  /* top gets extra 0.5em (both above and below) for the decoration;
+     then we add the padding to the bottom as well for symmetry */
+  margin-top: 2.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+.domintro::before, .note::before, .warning::before, .example::before {
+  padding: 0.15em 0.25em;
+  position: absolute;
+  top: -0.8em;
+  left: -0.8em;
+  color: white;
+}
 @media (max-width: 767px) {
-  dl.domintro, .note, .warning, .example { margin-top: 1.25em; margin-left: 0; padding: 1.5em 0.5em 0.5em 1.5em; }
-  .warning { padding-top: 2em; }
-  dl.domintro::before, .note::before, .warning::before, .example::before { top: -0.3em; left: -0.3em; }
+  .domintro, .note, .warning, .example {
+    margin-top: 2em;
+    padding-top: 1.5em;
+    padding-bottom: 0.5em;
+  }
+  .domintro::before, .note::before, .warning::before, .example::before {
+    top: -0.3em;
+    left: -0.3em;
+  }
 }
+
+/* These ones can be inline <span>s */
+span.note, span.warning, span.XXX {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+span.note {
+  padding-left: 3.5em;
+}
+span.warning {
+  padding-left: 6em;
+}
+span.note::before, span.warning::before {
+  left: 0;
+  top: -0.25em;
+}
+
+.domintro {
+  color: green;
+  background: #DDFFDD;
+}
+.domintro::before {
+  background: green;
+}
+.domintro dt, .domintro dt * {
+  color: black;
+}
+dl.domintro dd p {
+  margin: 0.5em 0;
+}
+dl.domintro dd p:first-child {
+  margin-top: 0;
+}
+dl.domintro dd p:last-child {
+  margin-bottom: 0;
+}
+
+.note {
+  color: green;
+  background: #DDFFDD;
+  font-style: italic;
+}
+.note::before {
+  background: green;
+}
+.note em, .note i, .note var, .note cite {
+  font-style: normal;
+}
+
+.warning {
+  color: red;
+  background: transparent;
+  font-weight: bolder;
+  font-style: italic;
+}
+.warning::before {
+  color: yellow;
+  background: red;
+}
+.warning em, .warning i, .warning var, .warning cite {
+  font-style: normal;
+}
+
+.example {
+  color: #222222;
+  background: #EEEEEE;
+}
+.example::before {
+  background: #222222;
+}
+td > .example:only-child {
+  margin: 0 0 0 0.1em;
+  padding: 0;
+}
+td > .example:only-child::before {
+  display: none;
+}
+
+
+.XXX {
+  color: #E50000;
+  background: white;
+  border: solid red;
+}
+
+.critical {
+  background: #FFFFCC;
+  border: double thick red;
+}
+
+
 
 figure.diagrams { border: thin solid black; background: white; padding: 1em; }
 figure.diagrams img { display: block; margin: 1em auto; }
@@ -228,10 +330,6 @@ hgroup h2, h1 + h2, hr + h2.no-toc { page-break-before: auto ! important; }
 .category-list li { display: inline; }
 .category-list li:not(:last-child)::after { content: ', '; }
 
-.big-issue, .XXX { color: #E50000; background: white; border: solid red; padding: 0.5em; margin: 1em 0; }
-.big-issue > :first-child, .XXX > :first-child { margin-top: 0; }
-p .big-issue, p .XXX { line-height: 3em; }
-
 .tablenote { margin: 0.25em 0; }
 .tablenote small { font-size: 0.9em; }
 
@@ -240,9 +338,6 @@ p .big-issue, p .XXX { line-height: 3em; }
 .bookkeeping p { margin: 0.5em 2em; display: list-item; list-style: square; }
 .bookkeeping dt { margin: 0.5em 2em 0; }
 .bookkeeping dd { margin: 0 3em 0.5em; }
-
-.critical { margin: 1em; border: double thick red; padding: 1em; background: #FFFFCC; }
-.critical > :first-child { margin-top: 0; }
 
 h4 { position: relative; z-index: 3; }
 h4 + .element, h4 + div.status + .element { margin-top: -2.75em; padding-top: 1.5em; }

--- a/resources.whatwg.org/test-spec-new.html
+++ b/resources.whatwg.org/test-spec-new.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<title>Stylesheet test</title>
+<meta charset="utf-8">
+<link rel="stylesheet" href="spec.css">
+<link rel="stylesheet" href="standard-new.css">
+<link rel="stylesheet" href="standard-shared-with-dev.css">
+
+<p>A paragraph</p>
+
+<p class="note">A note paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="example">An example paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="warning">A warning paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="XXX">An XXX paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="critical">A critical paragraph</p>
+
+<p>Another paragraph</p>
+
+<dl class="domintro">
+  <dt>A domintro dt</dt>
+  <dd>A domintro dd, no paragraphs</dd>
+
+  <dt>A domintro dt</dt>
+  <dd>
+    <p>A domintro dt, paragraph 1</p>
+    <p>A domintro dt, paragraph 2</p>
+  </dd>
+</dl>
+
+<div class="note">
+  <p>A note div: paragraph 1</p>
+
+  <p>A note div: paragraph 2</p>
+
+  <p>A note div: paragraph 3</p>
+</div>
+
+<div class="example">
+  <p>An example div: paragraph 1</p>
+
+  <p>An example div: paragraph 2</p>
+
+  <p>An example div: paragraph 3</p>
+</div>
+
+<div class="warning">
+  <p>A warning div: paragraph 1</p>
+
+  <p>A warning div: paragraph 2</p>
+
+  <p>A warning div: paragraph 3</p>
+</div>
+
+<div class="XXX">
+  <p>An XXX div: paragraph 1</p>
+
+  <p>An XXX div: paragraph 2</p>
+
+  <p>An XXX div: paragraph 3</p>
+</div>
+
+<div class="critical">
+  <p>A critical div: paragraph 1</p>
+
+  <p>A critical div: paragraph 2</p>
+
+  <p>A critical div: paragraph 3</p>
+</div>
+
+<div class="example">
+  <pre>An example div with pre child, no paragraphs</pre>
+</div>
+
+<p>A normal paragraph with an inline <span class="note">note</span> and some text after</p>
+
+<p>A normal paragraph with an inline <span class="warning">warning</span> and some text after</p>
+
+<p>A normal paragraph with an inline <span class="XXX">XXX</span> and some text after</p>
+
+<div class="example">
+  <a class="self-link" href=""></a>
+  <p>An example div with a self-link: paragraph 1</p>
+
+  <pre>Some pre contents</pre>
+</div>

--- a/resources.whatwg.org/test-spec.html
+++ b/resources.whatwg.org/test-spec.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<title>Stylesheet test</title>
+<meta charset="utf-8">
+<link rel="stylesheet" href="spec.css">
+<link rel="stylesheet" href="standard.css">
+<link rel="stylesheet" href="standard-shared-with-dev.css">
+
+<p>A paragraph</p>
+
+<p class="note">A note paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="example">An example paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="warning">A warning paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="XXX">An XXX paragraph</p>
+
+<p>Another paragraph</p>
+
+<p class="critical">A critical paragraph</p>
+
+<p>Another paragraph</p>
+
+<dl class="domintro">
+  <dt>A domintro dt</dt>
+  <dd>A domintro dd, no paragraphs</dd>
+
+  <dt>A domintro dt</dt>
+  <dd>
+    <p>A domintro dt, paragraph 1</p>
+    <p>A domintro dt, paragraph 2</p>
+  </dd>
+</dl>
+
+<div class="note">
+  <p>A note div: paragraph 1</p>
+
+  <p>A note div: paragraph 2</p>
+
+  <p>A note div: paragraph 3</p>
+</div>
+
+<div class="example">
+  <p>An example div: paragraph 1</p>
+
+  <p>An example div: paragraph 2</p>
+
+  <p>An example div: paragraph 3</p>
+</div>
+
+<div class="warning">
+  <p>A warning div: paragraph 1</p>
+
+  <p>A warning div: paragraph 2</p>
+
+  <p>A warning div: paragraph 3</p>
+</div>
+
+<div class="XXX">
+  <p>An XXX div: paragraph 1</p>
+
+  <p>An XXX div: paragraph 2</p>
+
+  <p>An XXX div: paragraph 3</p>
+</div>
+
+<div class="critical">
+  <p>A critical div: paragraph 1</p>
+
+  <p>A critical div: paragraph 2</p>
+
+  <p>A critical div: paragraph 3</p>
+</div>
+
+<div class="example">
+  <pre>An example div with pre child, no paragraphs</pre>
+</div>
+
+<p>A normal paragraph with an inline <span class="note">note</span> and some text after</p>
+
+<p>A normal paragraph with an inline <span class="warning">warning</span> and some text after</p>
+
+<p>A normal paragraph with an inline <span class="XXX">XXX</span> and some text after</p>
+
+<div class="example">
+    <a class="self-link" href=""></a>
+    <p>An example div with a self-link: paragraph 1</p>
+
+    <pre>Some pre contents</pre>
+  </div>


### PR DESCRIPTION
In particular, this uniformizes .domintro, .note, .warning, .example, .XXX, and .critical, in the following ways:

* Updates all of .domintro, .note, .warning, and .example to have the same style as the current .domintro for their decoration, with no tilt
* Updates all to the look the same for `<p class="thing">...</p>` and `<div class="thing"><p>...</p></div>`
* Updates all of them to have uniform padding and margin, so that e.g. the text aligns on the left, and the borders align on the left and right
* Improves the style for inline `<span>` versions of .note, .warning, and .XXX
* Removes the .big-issue synonym for .XXX
* Removes many redundant-in-practice rules that have accreted over time and serve only to create inconsistencies
* Makes it clearer what styles are shared, by explicitly sharing them, instead of repeating them
* Also de-italicizes `<cite>` inside italic contexts like .note or .warning (similar to `<em>`, `<i>`, and `<var>`)

Closes #187. Closes #189.

---

You can see a before/after comparison at:

- https://condescending-franklin-fe08bc.netlify.com/test-spec.html
- https://condescending-franklin-fe08bc.netlify.com/test-spec-new.html

If I were to tweak something further, I would add a background color to .warning; if folks have suggestions that'd be helpful.