### PR TITLE
Use GitHub URL for vnu.jar download

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -179,7 +179,7 @@ echo ""
 # Run the HTML checker only when building on Travis
 if [[ "$TRAVIS" == "true" ]]; then
     header "Running the HTML checker..."
-    curlretry --fail --remote-name https://sideshowbarker.net/nightlies/jar/vnu.jar
+    curlretry --fail --remote-name --location https://github.com/validator/validator/releases/download/jar/vnu.jar
     /usr/lib/jvm/java-8-oracle/jre/bin/java -jar vnu.jar --skip-non-html --Werror --filterpattern "$CHECKER_FILTER" "$WEB_ROOT"
     echo ""
 fi


### PR DESCRIPTION
This change makes the deploy.sh script download the vnu.jar file from https://github.com/validator/validator/releases/download/jar/vnu.jar (rather than from https://sideshowbarker.net/nightlies/jar/vnu.jar).