### PR TITLE
Use --filterfile for HTML checker

### DIFF
--- a/resources.whatwg.org/build/README.md
+++ b/resources.whatwg.org/build/README.md
@@ -23,6 +23,8 @@ Optional environment variables:
 - `$EXTRA_FILES` are extra files to copy for each build. Shell wildcards are allowed, and directory structure will be preserved. Example: `EXTRA_FILES="images/*.png"`.
 - `$POST_BUILD_STEP` is an extra step to run after each build. Evaluated with the `$DIR` variable set to the build directory. Example: `POST_BUILD_STEP='python generate-stuff.py "$DIR"'`.
 
+To cause particular errors or warnings emitted by the HTML checker to be suppressed, add a file named `.htmlcheckerfilter` at the root of the repo for a particular standard, and put filter patterns into it, as documented at https://github.com/validator/validator/wiki/Message-filtering#using-the---filterfile-option.
+
 An example `.travis.yml` file that uses this script would then be as follows:
 
 ```yaml

--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -26,9 +26,6 @@ SERVER_PUBLIC_KEY="ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzd
 EXTRA_FILES=${EXTRA_FILES:-}
 POST_BUILD_STEP=${POST_BUILD_STEP:-}
 
-# HTML checker filter passed to vnu.jar --filterpattern
-CHECKER_FILTER=${CHECKER_FILTER:-}
-
 if [[ "$TRAVIS" != "true" ]]; then
     echo "Running a local deploy into $WEB_ROOT directory"
 fi
@@ -183,10 +180,10 @@ if [[ "$TRAVIS" == "true" ]]; then
     header "Running the HTML checker..."
     curlretry --fail --remote-name --location https://github.com/validator/validator/releases/download/linux/vnu.linux.zip
     unzip vnu.linux.zip
-    if [ -z "$CHECKER_FILTER" ]; then
-      ./vnu-runtime-image/bin/vnu --skip-non-html --Werror "$WEB_ROOT"
+    if [ -f .htmlcheckerfilter ]; then
+      ./vnu-runtime-image/bin/vnu --skip-non-html --Werror --filterfile .htmlcheckerfilter "$WEB_ROOT"
     else
-      ./vnu-runtime-image/bin/vnu --skip-non-html --Werror --filterpattern "$CHECKER_FILTER" "$WEB_ROOT"
+      ./vnu-runtime-image/bin/vnu --skip-non-html --Werror "$WEB_ROOT"
     fi
     echo ""
 fi


### PR DESCRIPTION
This change causes the HTML checker to be invoked with the --filterfile argument if a file named `.htmlcheckerfilter` is found. The filter pattern (for suppressing particular messages from the checker) is then read from the specified file.

Otherwise, without this change, the HTML checker is instead invoked with the --filterpattern argument and the filer pattern is read directly from the CHECKER_FILTER environment variable. Testing in Travis CI indicates doing it that way doesn’t work as expected in some cases (due to shell escaping of the special characters and spaces in the pattern, or something.)