### PR TITLE
Invoke the HTML checker with the --verbose option

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -179,11 +179,11 @@ echo ""
 if [[ "$TRAVIS" == "true" ]]; then
     header "Running the HTML checker..."
     curlretry --fail --remote-name --location https://github.com/validator/validator/releases/download/linux/vnu.linux.zip
-    unzip vnu.linux.zip
+    unzip -q vnu.linux.zip
     if [ -f .htmlcheckerfilter ]; then
-      ./vnu-runtime-image/bin/vnu --skip-non-html --Werror --filterfile .htmlcheckerfilter "$WEB_ROOT"
+      ./vnu-runtime-image/bin/vnu --verbose --skip-non-html --Werror --filterfile .htmlcheckerfilter "$WEB_ROOT"
     else
-      ./vnu-runtime-image/bin/vnu --skip-non-html --Werror "$WEB_ROOT"
+      ./vnu-runtime-image/bin/vnu --verbose --skip-non-html --Werror "$WEB_ROOT"
     fi
     echo ""
 fi


### PR DESCRIPTION
This change causes the HTML checker to be invoked with the --verbose option. That causes the checker to emit the filename of every file it checks.

The advantages of using the --verbose option under CI are that:

* it ensures there will be continuous CI log output while the checker is running; and that in turns prevents us from ever hitting the case where the build reaches a no-log-output-for-more-than-N-minutes timeout (where for, e.g, Travis CI, the timeout is 10 minutes — and which we end up hitting in the case of the Encoding spec, where the checker is being run in CI on 66 files, and 30+ of those files are larger than 4MB each)

* it ensures that for anybody looking at (tailing) the CI log output, it won’t look like the build is hanging, when in fact it’s running the HTML checker (but just, e.g., on 66 files, 30+ of which are 4MB+ each)