### PR TITLE
Update Edge logo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ package-lock.json
 resources.whatwg.org/browser-logos/android-webview.png
 resources.whatwg.org/browser-logos/chrome.svg
 resources.whatwg.org/browser-logos/edge.svg
+resources.whatwg.org/browser-logos/edge_legacy.svg
 resources.whatwg.org/browser-logos/firefox.png
 resources.whatwg.org/browser-logos/ie-mobile.svg
 resources.whatwg.org/browser-logos/ie.png

--- a/deploy.sh
+++ b/deploy.sh
@@ -28,6 +28,7 @@ copy_logo() {
 copy_logo "android-webview-beta/android-webview-beta_32x32.png" "android-webview.png"
 copy_logo "chrome/chrome.svg" "chrome.svg"
 copy_logo "edge/edge.svg" "edge.svg"
+copy_logo "edge_12-18/edge_12-18.svg" "edge_legacy.svg"
 copy_logo "firefox/firefox_32x32.png" "firefox.png"
 copy_logo "internet-explorer-tile_10-11/internet-explorer-tile_10-11.svg" "ie-mobile.svg"
 copy_logo "internet-explorer_9-11/internet-explorer_9-11_32x32.png" "ie.png"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "devDependencies": {
         "@browser-logos/android-webview-beta": "^1.0.3",
         "@browser-logos/chrome": "^1.0.10",
-        "@browser-logos/edge": "^1.0.5",
+        "@browser-logos/edge": "^2.0.2",
+        "@browser-logos/edge_12-18": "^1.0.1",
         "@browser-logos/firefox": "^3.0.3",
         "@browser-logos/internet-explorer-tile_10-11": "^1.0.6",
         "@browser-logos/internet-explorer_9-11": "^1.1.6",

--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -195,6 +195,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 .mdnsupport > .edge::before, .mdnsupport > .edge_mobile::before {
   background-image: url(https://resources.whatwg.org/browser-logos/edge.svg);
 }
+.mdnsupport > .edge_legacy::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/edge_legacy.svg);
+}
 .mdnsupport > .firefox::before, .mdnsupport > .firefox_android::before {
   background-image: url(https://resources.whatwg.org/browser-logos/firefox.png);
 }


### PR DESCRIPTION
Not sure when the Edge logo should be updated, now or after the stable release date, but in any case, here is the PR for it. 

See also: https://blogs.windows.com/windowsexperience/2019/11/04/introducing-the-new-microsoft-edge-and-bing/

---

| Old logo | New Logo |
|:---|:---|
| ![](https://raw.githubusercontent.com/alrra/browser-logos/bb23044804e7f78320241d582b71bed1576657d1/src/archive/edge_12-18/edge_12-18_512x512.png) | ![](https://raw.githubusercontent.com/alrra/browser-logos/bb23044804e7f78320241d582b71bed1576657d1/src/edge/edge_512x512.png)

