### PR TITLE
Link to lists.whatwg.org from whatwg.org/mailing-list

### DIFF
--- a/whatwg.org/mailing-list
+++ b/whatwg.org/mailing-list
@@ -36,7 +36,10 @@ home.</p>
 
 <h3>Archives</h3>
 
-<p>A static archive is available at <a href="https://lists.whatwg.org/">lists.whatwg.org</a>.</p>
+<p>A static archive is available at <a href="https://lists.whatwg.org/">lists.whatwg.org</a>.
+If you've found a broken link to this archive, please
+<a href="https://github.com/whatwg/whatwg.org/issues/new">file an issue</a>. We may be able to
+recover it based on context.</p>
 
 <p>A separate <a href="https://lists.w3.org/Archives/Public/public-whatwg-archive/">whatwg@whatwg.org
 archive</a> is also maintained by the W3C, and this archive is searchable.</p>

--- a/whatwg.org/mailing-list
+++ b/whatwg.org/mailing-list
@@ -36,41 +36,10 @@ home.</p>
 
 <h3>Archives</h3>
 
-<p>The <a href="https://lists.w3.org/Archives/Public/public-whatwg-archive/">whatwg@whatwg.org
-archives</a> maintained by the W3C are publicly accessible.</p>
+<p>A static archive is available at <a href="https://lists.whatwg.org/">lists.whatwg.org</a>.</p>
 
-<p>Partial archives of whatwg@whatwg.org as well as "help" and "implementors" lists are available
-in the
-<a href="https://web.archive.org/web/20140401085615/http://lists.whatwg.org/listinfo.cgi">Wayback
-Machine</a>.</p>
-
-<p>Given a link to lists.whatwg.org, you can try finding it in the Wayback Machine:</p>
-
-<form>
- <input name=listsurl type=url value="http://lists.whatwg.org/listinfo.cgi" size=80>
- <input type=submit value=Go>
-</form>
-
-<script>
-'use strict';
-(() => {
-  const form = document.forms[0];
-  const input = form.firstElementChild;
-
-  // Redirect to web.archive.org on form submit.
-  form.addEventListener('submit', (event) => {
-    event.preventDefault();
-    window.location = 'https://web.archive.org/web/20140401085615/' + input.value;
-  });
-
-  // If redirected here from lists.whatwg.org, prefill the URL in the form.
-  const url = new URL(location.href);
-  const listsurl = url.searchParams.get('listsurl');
-  if (listsurl) {
-    input.value = listsurl;
-  }
-})();
-</script>
+<p>A separate <a href="https://lists.w3.org/Archives/Public/public-whatwg-archive/">whatwg@whatwg.org
+archive</a> is also maintained by the W3C, and this archive is searchable.</p>
 
 <footer>
  <p><small>Copyright © 2018 WHATWG (Apple, Google, Mozilla, Microsoft). This work is licensed under a <a rel="license" href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.</small></p>


### PR DESCRIPTION
Everything that could be recovered from the Wayback Machine has been
restored, so there's no reason to link to it. The redirect mechanism
was never deployed.