### PR TITLE
Slight readability improvements

### DIFF
--- a/resources.whatwg.org/review-draft.css
+++ b/resources.whatwg.org/review-draft.css
@@ -1,5 +1,5 @@
 pre.idl, pre.asn, pre.css, dl.domintro, .note, .warning, .example {
- border: 1px solid black;
+ border: 1px solid black; padding: 0.5em;
 }
 
 pre.idl::before, pre.asn::before, pre.css::before, dl.domintro::before, .note::before, .warning::before, .example::before {
@@ -8,8 +8,6 @@ pre.idl::before, pre.asn::before, pre.css::before, dl.domintro::before, .note::b
 
 body {
   margin-bottom: 3em; /* makes room for the .annoying-warning */
-}
-
-details.annoying-warning {
   font-family: Helvetica Neue, sans-serif, Droid Sans Fallback;
+  padding: 2.5em;
 }


### PR DESCRIPTION
There are a few things that really make review drafts hard to read for me:
* The browser's default serif font (no font-family set for the body)
* Lack of page padding and bordered box padding 

I'm hopeful that the following small tweaks will be acceptable to improve basic readability within the existing purpose and intent of the review draft format.