### PR TITLE
Editorial: remove dead code from convert-policy.py

### DIFF
--- a/convert-policy.py
+++ b/convert-policy.py
@@ -82,8 +82,6 @@ def markdown_title(policy_markdown):
 
             return (title, policy_markdown)
 
-    return ("Policies", policy_markdown)
-
 
 def main():
     link_mapping_pairs = parse_link_mapping(codecs.open("sg/policy-link-mapping.txt", "r", encoding="utf-8").read())

--- a/convert-policy.py
+++ b/convert-policy.py
@@ -82,6 +82,8 @@ def markdown_title(policy_markdown):
 
             return (title, policy_markdown)
 
+    assert False, "Markdown does not contain a line starting with # WHATWG "
+
 
 def main():
     link_mapping_pairs = parse_link_mapping(codecs.open("sg/policy-link-mapping.txt", "r", encoding="utf-8").read())


### PR DESCRIPTION
Between 4d34512aeb618c8753e317b220a7937c2161fb11 and https://github.com/whatwg/sg/pull/77 this became obsolete I think.