### PR TITLE
Specify the Python version to use on Travis (3.8)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: "3.8"
 
 env:
   global:


### PR DESCRIPTION
The default is now 3.6. The important thing here is to make it clear
that Python 3 is used in CI, since just `pip` and `python` are used
in scripts, which usually point to Python 2.