### PR TITLE
Editorial: normalize biblio.json

### DIFF
--- a/resources.whatwg.org/biblio.json
+++ b/resources.whatwg.org/biblio.json
@@ -1,71 +1,108 @@
 {
   "BOOKS": {
-    "authors": ["Håkon Wium Lie"],
+    "authors": [
+      "Håkon Wium Lie"
+    ],
     "href": "https://books.idea.whatwg.org/",
     "status": "Living Idea",
     "title": "CSS Books"
   },
-  "CONSOLE": {
-    "authors": ["Dominic Farolino", "Terin Stock", "Robert Kowalski"],
-    "href": "https://console.spec.whatwg.org/",
-    "title": "Console Standard"
-  },
-  "COMPAT" : {
-    "authors": ["Mike Taylor"],
+  "COMPAT": {
+    "authors": [
+      "Mike Taylor"
+    ],
     "href": "https://compat.spec.whatwg.org/",
     "title": "Compatibility Standard"
   },
+  "CONSOLE": {
+    "authors": [
+      "Dominic Farolino",
+      "Terin Stock",
+      "Robert Kowalski"
+    ],
+    "href": "https://console.spec.whatwg.org/",
+    "title": "Console Standard"
+  },
   "DIFFERENCES": {
-    "authors": ["Simon Pieters"],
+    "authors": [
+      "Simon Pieters"
+    ],
     "href": "https://html-differences.whatwg.org/",
     "title": "Differences from HTML4"
   },
   "DOM": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://dom.spec.whatwg.org/",
     "title": "DOM Standard"
   },
   "DOMPARSING": {
-    "obsoletedBy": ["DOM-Parsing"],
-    "authors": ["Ms2ger"],
+    "authors": [
+      "Ms2ger"
+    ],
     "href": "https://domparsing.spec.whatwg.org/",
+    "obsoletedBy": [
+      "DOM-Parsing"
+    ],
     "title": "DOM Parsing and Serialization Standard"
   },
   "ENCODING": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://encoding.spec.whatwg.org/",
     "title": "Encoding Standard"
   },
   "FETCH": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://fetch.spec.whatwg.org/",
     "title": "Fetch Standard"
   },
   "FIGURES": {
-    "authors": ["Håkon Wium Lie"],
+    "authors": [
+      "Håkon Wium Lie"
+    ],
     "href": "https://figures.idea.whatwg.org/",
     "status": "Living Idea",
     "title": "CSS Figures"
   },
   "FULLSCREEN": {
-    "authors": ["Philip Jägenstedt"],
+    "authors": [
+      "Philip Jägenstedt"
+    ],
     "href": "https://fullscreen.spec.whatwg.org/",
     "title": "Fullscreen API Standard"
   },
   "HTML": {
-    "authors": ["Anne van Kesteren", "Domenic Denicola", "Ian Hickson", "Philip Jägenstedt", "Simon Pieters"],
+    "authors": [
+      "Anne van Kesteren",
+      "Domenic Denicola",
+      "Ian Hickson",
+      "Philip Jägenstedt",
+      "Simon Pieters"
+    ],
     "href": "https://html.spec.whatwg.org/multipage/",
     "title": "HTML Standard"
   },
   "INFRA": {
-    "authors": ["Anne van Kesteren", "Domenic Denicola"],
+    "authors": [
+      "Anne van Kesteren",
+      "Domenic Denicola"
+    ],
     "href": "https://infra.spec.whatwg.org/",
     "title": "Infra Standard"
   },
   "JAVASCRIPT": {
-    "obsoletedBy": ["ECMASCRIPT"],
-    "authors": ["Mathias Bynens"],
+    "authors": [
+      "Mathias Bynens"
+    ],
     "href": "https://javascript.spec.whatwg.org/",
+    "obsoletedBy": [
+      "ECMASCRIPT"
+    ],
     "title": "JavaScript, a.k.a. Web ECMAScript"
   },
   "LOADER": {
@@ -74,37 +111,53 @@
     "title": "Loader"
   },
   "MIMESNIFF": {
-    "authors": ["Gordon P. Hemsley"],
+    "authors": [
+      "Gordon P. Hemsley"
+    ],
     "href": "https://mimesniff.spec.whatwg.org/",
     "title": "MIME Sniffing Standard"
   },
   "NOTIFICATIONS": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://notifications.spec.whatwg.org/",
     "title": "Notifications API Standard"
   },
   "QUIRKS": {
-    "authors": ["Simon Pieters"],
+    "authors": [
+      "Simon Pieters"
+    ],
     "href": "https://quirks.spec.whatwg.org/",
     "title": "Quirks Mode Standard"
   },
   "STORAGE": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://storage.spec.whatwg.org/",
     "title": "Storage Standard"
   },
   "STREAMS": {
-    "authors": ["Adam Rice", "Domenic Denicola", "吉野剛史 (Takeshi Yoshino)"],
+    "authors": [
+      "Adam Rice",
+      "Domenic Denicola",
+      "吉野剛史 (Takeshi Yoshino)"
+    ],
     "href": "https://streams.spec.whatwg.org/",
     "title": "Streams Standard"
   },
   "URL": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://url.spec.whatwg.org/",
     "title": "URL Standard"
   },
   "XHR": {
-    "authors": ["Anne van Kesteren"],
+    "authors": [
+      "Anne van Kesteren"
+    ],
     "href": "https://xhr.spec.whatwg.org/",
     "title": "XMLHttpRequest Standard"
   }


### PR DESCRIPTION
This is the result of running
```python
#!/usr/bin/env python

import json

biblio = json.load(open("resources.whatwg.org/biblio.json", "r"))
string = json.dumps(biblio, ensure_ascii=False, allow_nan=False, sort_keys=True, indent=2) + "\n"
open("resources.whatwg.org/biblio.json", "w").write(string)
```
to help with #303 as far as output comparisons go.