### PR TITLE
Make template suitable for other origins

### DIFF
--- a/convert-policy.py
+++ b/convert-policy.py
@@ -61,7 +61,7 @@ def preprocess_markdown(policy_markdown, mapping_pairs):
 
 def postprocess_html(policy_html, template, title):
     result = adjust_headers(policy_html)
-    result = template.replace("@POLICY_GOES_HERE@", result)
+    result = template.replace("@CONTENT_GOES_HERE@", result)
     result = result.replace("@TITLE_GOES_HERE@", title)
     result = result.replace("<p>EXAMPLE: ", "<p class=\"example\">")
     result = result.replace("<p>NOTE: ", "<p class=\"note\">")
@@ -83,7 +83,7 @@ def markdown_title(policy_markdown):
 
 def main():
     link_mapping_pairs = parse_link_mapping(open("sg/policy-link-mapping.txt", "r", encoding="utf-8").read())
-    template = open("policy-template.html", "r", encoding="utf-8").read()
+    template = open("site-template.html", "r", encoding="utf-8").read()
     for resource, link in link_mapping_pairs:
         if link.startswith("https:"):
             continue

--- a/site-template.html
+++ b/site-template.html
@@ -5,14 +5,14 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="theme-color" content="#3A7908">
 <link rel="icon" href="https://resources.whatwg.org/logo.svg">
-<link rel="stylesheet" href="/style/shared.css">
-<link rel="stylesheet" href="/style/subpages.css">
+<link rel="stylesheet" crossorigin="" href="https://whatwg.org/style/shared.css">
+<link rel="stylesheet" crossorigin="" href="https://whatwg.org/style/subpages.css">
 
 <header>
  <hgroup>
   <h1>
    <a href="/">
-    <img id="main-logo" src="https://resources.whatwg.org/logo.svg" alt="">
+    <img id="main-logo" crossorigin="" src="https://resources.whatwg.org/logo.svg" alt="">
     WHATWG
    </a>
   </h1>
@@ -22,12 +22,12 @@
 
 <nav class="buttonish-links">
  <a href="https://spec.whatwg.org/">Standards</a>
- <a href="/faq">FAQ</a>
- <a href="/policies">Policies</a>
+ <a href="https://whatwg.org/faq">FAQ</a>
+ <a href="https://whatwg.org/policies">Policies</a>
  <a href="https://participate.whatwg.org/">Participate</a>
 </nav>
 
-@POLICY_GOES_HERE@
+@CONTENT_GOES_HERE@
 
 <script>
 "use strict";


### PR DESCRIPTION
For #303 I'd like to use this template for spec.whatwg.org and idea.whatwg.org.

This also adds some crossorigin="" attributes.