### PR TITLE
Change MDN-annotation styles to Bikeshed styles

### DIFF
--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -93,7 +93,227 @@ c-[vg] { color: #0077aa } /* Name.Variable.Global */
 c-[vi] { color: #0077aa } /* Name.Variable.Instance */
 c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 
-/* MDN margin annotations */
+/* MDN margin annotations; shared among both HTML and Bikeshed specs */
+@media (max-width: 767px) { .mdn-anno { opacity: .1 } }
+.mdn-anno {
+  font: 1em sans-serif;
+  padding: 0.3em;
+  position: absolute;
+  z-index: 8;
+  right: 0.3em;
+  background: #EEE;
+  color: black;
+  box-shadow: 0 0 3px #999;
+  overflow: hidden;
+  border-collapse: initial;
+  border-spacing: initial;
+  min-width: 9em;
+  max-width: min-content;
+  white-space: nowrap;
+  word-wrap: normal;
+  hyphens: none;
+}
+.mdn-anno:not(.wrapped) {
+  opacity: 1;
+}
+.mdn-anno:hover {
+  z-index: 9;
+}
+.mdn-anno:focus-within {
+  z-index: 11;
+}
+.mdn-anno.wrapped {
+  min-width: 0;
+}
+.mdn-anno.wrapped > :not(button) {
+  display: none;
+}
+.mdn-anno > .mdn-anno-btn {
+  cursor: pointer;
+  border: none;
+  color: #000;
+  background: transparent;
+  margin: -8px;
+  float: right;
+  padding: 10px 8px 8px 8px;
+  outline: none;
+}
+.mdn-anno > .mdn-anno-btn > .less-than-two-engines-flag {
+  color: red;
+  padding-right: 2px;
+}
+.mdn-anno > .mdn-anno-btn > .all-engines-flag {
+  color: green;
+  padding-right: 2px;
+}
+.mdn-anno > .mdn-anno-btn > span {
+  color: #fff;
+  background-color: #000;
+  font-weight: normal;
+  font-family: zillaslab,Palatino,"Palatino Linotype",serif;
+  padding: 2px 3px 0px 3px;
+  line-height: 1.3em;
+  vertical-align: top;
+}
+.mdn-anno > .feature {
+  margin-top: 20px;
+}
+.mdn-anno > .feature:not(:first-of-type) {
+  border-top: 1px solid #999;
+  margin-top: 6px;
+  padding-top: 2px;
+}
+.mdn-anno > .feature > .less-than-two-engines-text {
+  color: red
+}
+.mdn-anno > .feature > .all-engines-text {
+  color: green
+}
+.mdn-anno > .feature > p {
+  font-size: .75em;
+  margin-top: 6px;
+  margin-bottom: 0;
+}
+.mdn-anno > .feature > p + p {
+  margin-top: 3px;
+}
+.mdn-anno > .feature > p > a[href] {
+  color: #034575;
+  text-decoration: none;
+  border-bottom: 1px solid #707070;
+  padding: 0 1px 0;
+  margin: 0 -1px 0;
+}
+.mdn-anno > .feature > p > a[href]:focus,
+.mdn-anno > .feature > p > a[href]:hover {
+  background: #f8f8f8;
+  background: rgba(75%, 75%, 75%, .25);
+  border-bottom-width: 3px;
+  margin-bottom: -2px;
+}
+.mdn-anno > .feature > p > a[href]:active {
+  color: #C00;
+  border-color: #C00;
+}
+.mdn-anno > .feature > .support {
+  display: block;
+  font-size: 0.6em;
+  margin: 0;
+  padding: 0;
+  margin-top: 2px
+}
+.mdn-anno > .feature > .support + div {
+  padding-top: 0.5em;
+}
+.mdn-anno > .feature > .support > hr {
+  display: block;
+  border: none;
+  border-top: 1px dotted #999;
+  padding: 3px 0px 0px 0px;
+  margin: 2px 3px 0px 3px;
+}
+.mdn-anno > .feature > .support > hr::before {
+  content: "";
+}
+.mdn-anno > .feature > .support > span {
+  padding: 0.2em;
+  display: block;
+  display: table;
+}
+.mdn-anno > .feature > .support > span.no,
+.mdn-anno > .feature > .support > span.unknown {
+  color: #CCCCCC;
+  filter: grayscale(100%);
+}
+.mdn-anno > .feature > .support > span.no::before
+.mdn-anno > .feature > .support > span.unknown::before {
+  opacity: 0.5;
+}
+.mdn-anno > .feature > .support > span:hover {
+  color: white;
+  filter: none;
+  background: #666;
+}
+.mdn-anno > .feature > .support > span:first-of-type {
+  margin-top: 0.5em;
+}
+.mdn-anno > .feature > .support > span > span {
+  padding: 1px 0.5em 0 0.5em;
+  display: table-cell;
+}
+.mdn-anno > .feature > .support > span > span:first-child {
+  width: 100%;
+}
+.mdn-anno > .feature > .support > span > span:last-child {
+  width: 100%;
+  white-space: pre;
+  padding: 0;
+}
+.mdn-anno > .feature > .support > span::before {
+  content: ' ';
+  display: table-cell;
+  min-width: 1.5em;
+  height: 1.5em;
+  background: no-repeat center center;
+  background-size: contain;
+  text-align: right;
+  font-size: 0.75em;
+  font-weight: bold;
+}
+.mdn-anno > .feature > .support > .chrome_android::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg);
+}
+.mdn-anno > .feature > .support > .firefox_android::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/firefox.png);
+}
+.mdn-anno > .feature > .support > .chrome::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/chrome.svg);
+}
+.mdn-anno > .feature > .support > .edge_blink::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/edge.svg);
+}
+.mdn-anno > .feature > .support > .edge::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/edge_legacy.svg);
+}
+.mdn-anno > .feature > .support > .firefox::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/firefox.png);
+}
+.mdn-anno > .feature > .support > .ie::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/ie.png);
+}
+.mdn-anno > .feature > .support > .safari_ios::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/safari-ios.svg);
+}
+.mdn-anno > .feature > .support > .nodejs::before {
+  background-image: url(https://nodejs.org/static/images/favicons/favicon.ico);
+}
+.mdn-anno > .feature > .support > .opera_android::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/opera.svg);
+}
+.mdn-anno > .feature > .support > .opera::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/opera.svg);
+}
+.mdn-anno > .feature > .support > .safari::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/safari.png);
+}
+.mdn-anno > .feature > .support > .samsunginternet_android::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/samsung.svg);
+}
+.mdn-anno > .feature > .support > .webview_android::before {
+  background-image: url(https://resources.whatwg.org/browser-logos/android-webview.png);
+}
+.name-slug-mismatch {
+  color: red;
+}
+p + .mdn-anno { margin-top: -45px; }
+.mdn-anno.before { margin-top: 2px; }
+h2 + .mdn-anno, h2 + div.status + .mdn-anno { margin: -48px 0 0 0; }
+h3 + .mdn-anno, h3 + div.status + .mdn-anno { margin: -46px 0 0 0; }
+h4 + .mdn-anno, h4 + div.status + .mdn-anno { margin: -42px 0 0 0; }
+h5 + .mdn-anno, h5 + div.status + .mdn-anno { margin: -40px 0 0 0; }
+h6 + .mdn-anno, h6 + div.status + .mdn-anno { margin: -40px 0 0 0; }
+
+/* MDN margin annotations (pre-Bikeshed) */
 
 .mdn {
   display: block;


### PR DESCRIPTION
This changes add CSS styles for the MDN annotations generated by Bikeshed. The change also removes the existing CSS styles we were using for the MDN annotations generated by Wattsi for the HTML standard.

(A separate change to the Wattsi sources will revise the element markup and attribute markup generated by Wattsi such that it matches what Bikeshed generates — allowing the CSS styles in this change to be be used/shared among the HTML standard and all other WHATWG standards.)