### PR TITLE
Do not italicize <pre> inside notes

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -272,7 +272,7 @@ dl.domintro dd p:last-child {
 .note::before {
   background: green;
 }
-.note em, .note i, .note var, .note cite {
+.note em, .note i, .note var, .note cite, .note pre {
   font-style: normal;
 }
 


### PR DESCRIPTION
Inspired by https://github.com/whatwg/url/pull/495.

Before:

![image](https://user-images.githubusercontent.com/617481/81196679-56582780-8f8d-11ea-8f19-bda1c05264d7.png)

After:

![image](https://user-images.githubusercontent.com/617481/81196638-4d675600-8f8d-11ea-93e4-5b24f18c37e8.png)
