### PR TITLE
standard.css: pre { font-style: normal }

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -501,6 +501,7 @@ ul.domTree code :link, ul.domTree code :visited { color: inherit; }
 pre {
   margin: 0.5em 2em;
   white-space: pre-wrap;
+  font-style: normal;
 }
 
 pre > code, pre.highlight, pre.idl {


### PR DESCRIPTION
This avoids a .note italicizing it: https://github.com/whatwg/url/pull/495.