### PR TITLE
standard.css: code { font-style:normal }

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -48,7 +48,7 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
   .selected-text-file-an-issue { left: 0; right: auto; text-align: left; }
 }
 
-code { color: #666666; font-style:normal; }
+code { color: #666666; font-style: normal; }
 dfn code { color: orangered; }
 code :link, :link code, code :visited, :visited code { color: orangered; }
 pre :link, pre :visited { color: inherit; }

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -48,7 +48,7 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
   .selected-text-file-an-issue { left: 0; right: auto; text-align: left; }
 }
 
-code { color: #666666; }
+code { color: #666666; font-style:normal; }
 dfn code { color: orangered; }
 code :link, :link code, code :visited, :visited code { color: orangered; }
 pre :link, pre :visited { color: inherit; }


### PR DESCRIPTION
This would make the warning in https://encoding.spec.whatwg.org/#dom-textdecoder-decode look a bit better (to me).