### PR TITLE
Remove HTML-specific dfn panel styles from standard.css

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -434,29 +434,6 @@ html:not(.split) #multipage-link { animation: 10s ease 0s 1 stand-out; }
 p.copyright { text-align: center; }
 p.copyright > span { display: inline-block; border: none; }
 
-body.dfnEnabled dfn, body.dfnEnabled h2[data-dfn-type], body.dfnEnabled h3[data-dfn-type], body.dfnEnabled h4[data-dfn-type], body.dfnEnabled h5[data-dfn-type], body.dfnEnabled h6[data-dfn-type] { cursor: pointer; }
-.dfnPanel {
-  cursor: auto;
-  display: inline;
-  position: absolute;
-  z-index: 35;
-  height: auto;
-  width: auto;
-  padding: 0.5em 0.75em;
-  font: small Helvetica Neue, sans-serif, Droid Sans Fallback;
-  background: #DDDDDD;
-  color: black;
-  border: outset 0.2em;
-}
-.dfnPanel * { margin: 0; padding: 0; font: inherit; text-indent: 0; }
-.dfnPanel :link, .dfnPanel :visited { color: black; cursor: pointer; }
-/* Delicate specificity wars to pretend isolation from pre:hover rules elsewhere... */
-.dfnPanel *, pre:hover .dfnPanel * { text-decoration: none; }
-pre:hover .dfnPanel :link:hover, pre:hover .dfnPanel :visited:hover { text-decoration: underline; }
-.dfnPanel p:not(.spec-link) { font-weight: bolder; }
-.dfnPanel * + p { margin-top: 0.25em; }
-.dfnPanel li { list-style-position: inside; list-style-type: disc; }
-
 @media print {
   html { font-size: 8pt; }
   @page { margin: 1cm 1cm 1cm 1cm; }


### PR DESCRIPTION
Needs to follow https://github.com/whatwg/html/pull/5549.