### PR TITLE
Use `android-webview` instead of the `android-webview-beta` package

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -27,7 +27,7 @@ copy_logo() {
     echo "  $source_file => $target_file"
     cp "$source_file" "$target_file"
 }
-copy_logo "android-webview-beta/android-webview-beta_32x32.png" "android-webview.png"
+copy_logo "android-webview/android-webview_32x32.png" "android-webview.png"
 copy_logo "chrome/chrome.svg" "chrome.svg"
 copy_logo "edge/edge.svg" "edge.svg"
 copy_logo "edge_12-18/edge_12-18.svg" "edge_legacy.svg"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "private": true,
     "devDependencies": {
-        "@browser-logos/android-webview-beta": "^1.0.3",
+        "@browser-logos/android-webview": "^1.0.1",
         "@browser-logos/chrome": "^1.0.10",
         "@browser-logos/edge": "^2.0.2",
         "@browser-logos/edge_12-18": "^1.0.1",


### PR DESCRIPTION
The `Android WebView` was (is?) actually part of the Android Beta program, but now there is `Android WebView Beta`, so the `browser-logos` packages have been updated accordingly.

Ref: 

* https://play.google.com/store/apps/details?id=com.google.android.webview
* https://play.google.com/store/apps/details?id=com.google.android.webview.beta

![](https://user-images.githubusercontent.com/1223565/84598571-8adac100-ae20-11ea-9c2d-a2fa9f931353.png)
![](https://user-images.githubusercontent.com/1223565/84598572-8b735780-ae20-11ea-917f-958527d56742.png)