### PR TITLE
Skip deploy step for forks of our spec repos

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -178,8 +178,8 @@ if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     echo ""
 fi
 
-# Deploy from push to master branch only
-if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/master" ]]; then
+# Deploy from push to master branch on non-forks only
+if [[ "$GITHUB_REPOSITORY" == whatwg/* && "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/master" ]]; then
     header "rsync to the WHATWG server..."
     eval "$(ssh-agent -s)"
     echo "$SERVER_DEPLOY_KEY" | ssh-add -


### PR DESCRIPTION
https://github.com/shivanigithub/fetch/runs/776676042 failed of
attempting to deploy from a fork where the secrets aren't present.