### PR TITLE
Add a repository_dispatch hook for whatwg/sg updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
     - master
+  # Trigger for changes in the whatwg/sg repo.
+  repository_dispatch:
+    types:
+    - sg
 jobs:
   build:
     name: Build


### PR DESCRIPTION
This is half of the solution, in addition the sg repository will need to
trigger the event:
https://developer.github.com/v3/repos/#create-a-repository-dispatch-event

Part of https://github.com/whatwg/sg/issues/110.