### PR TITLE
Actually deploy for the repository_dispatch event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   # Trigger for changes in the whatwg/sg repo.
   repository_dispatch:
     types:
-    - sg
+    - sg_repo_updated
 jobs:
   build:
     name: Build

--- a/deploy.sh
+++ b/deploy.sh
@@ -56,8 +56,10 @@ if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     echo ""
 fi
 
-# This ensures that only changes to the master branch get deployed
-if [[ "$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/master" ]]; then
+# This ensures that only changes to the master branch get deployed.
+# (The repository_dispatch event is always for the master branch.)
+if [[ ("$GITHUB_EVENT_NAME" == "push" && "$GITHUB_REF" == "refs/heads/master") ||
+      "$GITHUB_EVENT_NAME" == "repository_dispatch" ]]; then
     header "Synchronizing content with whatwg.org et al"
     eval "$(ssh-agent -s)"
     echo "$SERVER_DEPLOY_KEY" | ssh-add -


### PR DESCRIPTION
Also change the event name to be a bit more explicit, since the event
name shows up in the list of triggered actions and a longer name will be
easier to spot or search for:
https://github.com/whatwg/whatwg.org/actions