### PR TITLE
Add stylesheet refinements for MDN annos

### DIFF
--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -332,7 +332,9 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
 .name-slug-mismatch {
   color: red;
 }
-p + .mdn-anno { margin-top: -45px; }
+/* We need this margin adjustment for MDN annos in the HTML spec, but we
+ * don’t want it for Bikeshed-generated (<body class="h-entry">) specs. */
+:not(.h-entry) p + .mdn-anno { margin-top: -45px; }
 .mdn-anno.before { margin-top: 2px; }
 td > .mdn-anno.before, dt > .mdn-anno.before { margin-top: -26px; }
 h2 + .mdn-anno { margin: -48px 0 0 0; }
@@ -340,6 +342,14 @@ h3 + .mdn-anno { margin: -46px 0 0 0; }
 h4 + .mdn-anno { margin: -42px 0 0 0; }
 h5 + .mdn-anno { margin: -40px 0 0 0; }
 h6 + .mdn-anno { margin: -40px 0 0 0; }
+/* .domintro, .note, .warning, and .example are "position: relative", so
+ * to put anno at right margin, must move to right of containing block */
+.domintro .mdn-anno,
+.note .mdn-anno,
+.warning .mdn-anno,
+.example .mdn-anno {
+  right: -9.7em;
+}
 
 /* MDN margin annotations (pre-Bikeshed) */
 


### PR DESCRIPTION
This change adds some additional CSS style adjustments related to MDN annos:

* one style adjustment that’s necessary due to the fact we’re sharing styles among both the HTML spec and WHATWG Bikeshed-generated specs.

* one style adjustment that’s necessary due to the fact the existing styles have "position: relative" for domintro boxes, as well as notes, warnings, and examples — so in cases where we have an element with an MDN anno inside of one of those, we need to move it to the right to get it out of containing block and back over to the right margin