### PR TITLE
Do not run convert_policy.py when it is imported

### DIFF
--- a/convert_policy.py
+++ b/convert_policy.py
@@ -101,4 +101,5 @@ def main():
 
         open("whatwg.org/" + link, "w", encoding="utf-8").write(postprocessed_policy_html)
 
-main()
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I guess running this twice is non-destructive, but it does not seem ideal. I only found out this is a thing that happens in Python because I was trying to have some code reuse over in whatwg/meta.