### PR TITLE
Add space to color space

### DIFF
--- a/whatwg.org/style-guide
+++ b/whatwg.org/style-guide
@@ -41,7 +41,7 @@
  <li>canceled</li>
  <li>canceling</li>
  <li>cipher</li>
- <li>colorspace</li>
+ <li>color space</li>
  <li>email</li>
  <li>filename</li>
  <li>implementer</li>


### PR DESCRIPTION
It has been colorspace in this document since the very beginning (7 November 2016), but on 9 May 2016 we changed colorspace to color space in the HTML Standard quite deliberately: https://github.com/whatwg/html/commit/c92fee202c1b4076209c127fc2151df1d2f68f98.

Recently this was discussed further in https://github.com/whatwg/html/pull/6562 and we decided to stick with color space.