### PR TITLE
Revert "build.sh: adjust HTML checker download location"

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -50,7 +50,7 @@ if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     readarray -d '' TARGETS < <(find whatwg.org -maxdepth 1 -type f ! -name "*.*" ! -name "status-2008-12" -print0)
     TARGETS+=(whatwg.org/news whatwg.org/validator whatwg.org/index.html idea.whatwg.org/index.html spec.whatwg.org/index.html)
 
-    curl --retry 2 --fail --remote-name --location https://github.com/validator/validator/releases/latest/download/vnu.linux.zip
+    curl --retry 2 --fail --remote-name --location https://github.com/validator/validator/releases/download/linux/vnu.linux.zip
     unzip -qq vnu.linux.zip
     ./vnu-runtime-image/bin/vnu --Werror "${TARGETS[@]}"
     echo ""

--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -170,7 +170,7 @@ echo ""
 # Run the HTML checker only in CI
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     header "Running the HTML checker..."
-    curlretry --fail --remote-name --location https://github.com/validator/validator/releases/latest/download/vnu.linux.zip
+    curlretry --fail --remote-name --location https://github.com/validator/validator/releases/download/linux/vnu.linux.zip
     unzip -q vnu.linux.zip
     if [ -f .htmlcheckerfilter ]; then
       ./vnu-runtime-image/bin/vnu --verbose --skip-non-html --Werror --filterfile .htmlcheckerfilter "$WEB_ROOT"


### PR DESCRIPTION
This reverts commit 7fa32e39833f777f5912790892b704399b9c308f.

https://github.com/validator/validator/releases/download/linux/vnu.linux.zip is working again now, and is the right URL to use.

https://github.com/validator/validator/releases/latest/download/vnu.linux.zip works, but it’s the URL for the most-recent stable release — which at this point is almost 1 year old.