### PR TITLE
Use new domain for matrix logs

### DIFF
--- a/whatwg.org/chat
+++ b/whatwg.org/chat
@@ -50,7 +50,7 @@
 <p>Chat logs can be found in the following places:</p>
 
 <ul>
- <li><a href="https://bakkot.github.io/matrix-logs/WHATWG">https://bakkot.github.io/matrix-logs/WHATWG</a> (Matrix room)</li>
+ <li><a href="https://matrixlogs.bakkot.com/WHATWG/">https://matrixlogs.bakkot.com/WHATWG/</a> (Matrix room)</li>
  <li><a href="https://view.matrix.org/room/!AGetWbsMpFPdSgUrbs:matrix.org/">https://view.matrix.org/room/!AGetWbsMpFPdSgUrbs:matrix.org/</a> (Matrix room)</li>
  <li><a href="https://freenode.logbot.info/whatwg">https://freenode.logbot.info/whatwg</a> (IRC channel)</li>
  <li><a href="https://krijnhoetmer.nl/irc-logs/">https://krijnhoetmer.nl/irc-logs/</a> (IRC channel; historical — not updated since 2016-04)</li>


### PR DESCRIPTION
Followup to #366. I've added a custom domain so I can keep the links stable in case we move the logs to some other repo or service.