### PR TITLE
Add lint step for ambiguous list literals

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -89,7 +89,7 @@ MATCHES=$(
   grep -niE '\s+$' "$INPUT_FILE" | perl -lpe 'print "\nTrailing whitespace:" if $. == 1'
   grep $'\t' "$INPUT_FILE" | perl -lpe 'print "\nTab:" if $. == 1'
   grep $'\xc2\xa0' "$INPUT_FILE" | perl -lpe 'print "\nUnescaped nonbreaking space:" if $. == 1'
-  grep $'[≪≫]' fetch.bs | perl -lpe 'print "\nWrong list literals:" if $. == 1'
+  grep $'[\u226a\u226b]' fetch.bs | perl -lpe 'print "\nWrong list literals, use \uAB\uBB instead:" if $. == 1'
 )
 if [ -n "$MATCHES" ]; then
   echo "$MATCHES"

--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -89,6 +89,7 @@ MATCHES=$(
   grep -niE '\s+$' "$INPUT_FILE" | perl -lpe 'print "\nTrailing whitespace:" if $. == 1'
   grep $'\t' "$INPUT_FILE" | perl -lpe 'print "\nTab:" if $. == 1'
   grep $'\xc2\xa0' "$INPUT_FILE" | perl -lpe 'print "\nUnescaped nonbreaking space:" if $. == 1'
+  grep $'[≪≫]' fetch.bs | perl -lpe 'print "\nWrong list literals:" if $. == 1'
 )
 if [ -n "$MATCHES" ]; then
   echo "$MATCHES"

--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -89,7 +89,7 @@ MATCHES=$(
   grep -niE '\s+$' "$INPUT_FILE" | perl -lpe 'print "\nTrailing whitespace:" if $. == 1'
   grep $'\t' "$INPUT_FILE" | perl -lpe 'print "\nTab:" if $. == 1'
   grep $'\xc2\xa0' "$INPUT_FILE" | perl -lpe 'print "\nUnescaped nonbreaking space:" if $. == 1'
-  grep $'[\u226a\u226b]' fetch.bs | perl -lpe 'print "\nWrong list literals, use \uAB\uBB instead:" if $. == 1'
+  grep $'[\u226a\u226b]' "$INPUT_FILE" | perl -lpe 'print "\nWrong list literals, use \uAB\uBB instead:" if $. == 1'
 )
 if [ -n "$MATCHES" ]; then
   echo "$MATCHES"


### PR DESCRIPTION
The "much greater/less than" unicode characters that look like list literals, I've made this mistake a few times... Lint would catch this early.
I don't think we need the "much greater/less than" characters in specs.