### PR TITLE
Tweak colour contrast

### DIFF
--- a/images.whatwg.org/content-venn.svg
+++ b/images.whatwg.org/content-venn.svg
@@ -11,7 +11,7 @@
   li { display: inline; margin: 0; padding: 0; line-height: 1.5; }
   li:not(:last-child):after { content: ', '; }
   span { font: italic 14px sans-serif; }
-  code { font: 1em monospace; color: #ce3c05; }
+  code { font: 1em monospace; color: #CE3C05; }
   p { margin: 0.75em 0 0 0; padding: 0 0 0 1em; font: italic 14px sans-serif; }
  </style>
  <g class="a" transform="translate(2, -3)">

--- a/images.whatwg.org/content-venn.svg
+++ b/images.whatwg.org/content-venn.svg
@@ -11,7 +11,7 @@
   li { display: inline; margin: 0; padding: 0; line-height: 1.5; }
   li:not(:last-child):after { content: ', '; }
   span { font: italic 14px sans-serif; }
-  code { font: 1em monospace; color: orangered; }
+  code { font: 1em monospace; color: #ce3c05; }
   p { margin: 0.75em 0 0 0; padding: 0 0 0 1em; font: italic 14px sans-serif; }
  </style>
  <g class="a" transform="translate(2, -3)">

--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -101,7 +101,7 @@ c-[il] { color: #000000 } /* Literal.Number.Integer.Long */
   position: absolute;
   z-index: 8;
   right: 0.3em;
-  background: #EEE;
+  background: #F7F7F7;
   color: black;
   box-shadow: 0 0 3px #999;
   overflow: hidden;
@@ -488,9 +488,9 @@ h6 + .mdn-anno { margin: -40px 0 0 0; }
  h6 + .mdn { margin: -40px 0 0 0; }
 
 .mdn > div { margin: 0; padding-bottom: 1px; }
-.mdn > div > .less-than-two-engines-flag { color: red; background-color: #eee; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; }
+.mdn > div > .less-than-two-engines-flag { color:#d50606; background-color: #F7F7F7; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; }
 .mdn > div > .all-engines-flag { color: green; background-color: #eee; }
-.mdn > div > details > .less-than-two-engines-text { color: red; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
+.mdn > div > details > .less-than-two-engines-text { color: #d50606; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
 .mdn > div > details > .all-engines-text { color: green; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
 .mdn > div:last-of-type details > .all-engines-text, .mdn > div:last-of-type > details > .less-than-two-engines-text { padding-bottom: 0; margin-bottom: 0; }
 .mdn :link { color: #0000EE; }

--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -488,7 +488,7 @@ h6 + .mdn-anno { margin: -40px 0 0 0; }
  h6 + .mdn { margin: -40px 0 0 0; }
 
 .mdn > div { margin: 0; padding-bottom: 1px; }
-.mdn > div > .less-than-two-engines-flag { color:#d50606; background-color: #F7F7F7; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; }
+.mdn > div > .less-than-two-engines-flag { color: #d50606; background-color: #F7F7F7; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; }
 .mdn > div > .all-engines-flag { color: green; background-color: #eee; }
 .mdn > div > details > .less-than-two-engines-text { color: #d50606; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
 .mdn > div > details > .all-engines-text { color: green; font-weight: bold; margin-top: 0; padding-bottom: 12px; }

--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -488,9 +488,9 @@ h6 + .mdn-anno { margin: -40px 0 0 0; }
  h6 + .mdn { margin: -40px 0 0 0; }
 
 .mdn > div { margin: 0; padding-bottom: 1px; }
-.mdn > div > .less-than-two-engines-flag { color: #d50606; background-color: #F7F7F7; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; }
+.mdn > div > .less-than-two-engines-flag { color: #D50606; background-color: #F7F7F7; font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif; }
 .mdn > div > .all-engines-flag { color: green; background-color: #eee; }
-.mdn > div > details > .less-than-two-engines-text { color: #d50606; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
+.mdn > div > details > .less-than-two-engines-text { color: #D50606; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
 .mdn > div > details > .all-engines-text { color: green; font-weight: bold; margin-top: 0; padding-bottom: 12px; }
 .mdn > div:last-of-type details > .all-engines-text, .mdn > div:last-of-type > details > .less-than-two-engines-text { padding-bottom: 0; margin-bottom: 0; }
 .mdn :link { color: #0000EE; }

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -49,8 +49,8 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
 }
 
 code { color: #666666; font-style: normal; }
-dfn code { color: orangered; }
-code :link, :link code, code :visited, :visited code { color: orangered; }
+dfn code { color: #ce3c05; }
+code :link, :link code, code :visited, :visited code { color: #ce3c05; }
 pre :link, pre :visited { color: inherit; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }
@@ -175,7 +175,7 @@ dl.triple { padding: 0 0 0 1em; }
 dl.triple dt, dl.triple dd { margin: 0; display: inline }
 dl.triple dt:after { content: ':'; }
 dl.triple dd:after { content: '\A'; white-space: pre; }
-tr.rare { background: #EEEEEE; color: #333333; }
+tr.rare { background: #F7F7F7; color: #333333; }
 
 /*
  * .domintro, .note, .warning, .example, .XXX, .critical
@@ -292,7 +292,7 @@ dl.domintro dd p:last-child {
 
 .example {
   color: #222222;
-  background: #EEEEEE;
+  background: #F5F5F5;
 }
 .example::before {
   background: #222222;
@@ -509,7 +509,7 @@ pre > code.idl::before, pre.idl::before, pre > code.css::before, pre.highlight.l
 }
 
 pre > code.idl, pre.idl {
-  background: #EEE;
+  background: #F5F5F5;
 }
 
 pre > code.css, pre.highlight.lang-css {

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -277,14 +277,14 @@ dl.domintro dd p:last-child {
 }
 
 .warning {
-  color: #CE3C05;
+  color: #D50606;
   background: #FFFFCA;
   font-weight: bolder;
   font-style: italic;
 }
 .warning::before {
   color: yellow;
-  background: #CE3C05;
+background: #D50606;
 }
 .warning em, .warning i, .warning var, .warning cite {
   font-style: normal;
@@ -292,7 +292,7 @@ dl.domintro dd p:last-child {
 
 .example {
   color: #222222;
-  background: #F5F5F5;
+  background: #F7F7F7;
 }
 .example::before {
   background: #222222;
@@ -509,7 +509,7 @@ pre > code.idl::before, pre.idl::before, pre > code.css::before, pre.highlight.l
 }
 
 pre > code.idl, pre.idl {
-  background: #F5F5F5;
+  background: #F7F7F7;
 }
 
 pre > code.css, pre.highlight.lang-css {

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -284,7 +284,7 @@ dl.domintro dd p:last-child {
 }
 .warning::before {
   color: yellow;
-background: #D50606;
+  background: #D50606;
 }
 .warning em, .warning i, .warning var, .warning cite {
   font-style: normal;
@@ -306,14 +306,14 @@ td > .example:only-child::before {
 }
 
 .XXX {
-  color: #E50000;
+  color: #D50606;
   background: white;
-  border: solid red;
+  border: solid #D50606;
 }
 
 .critical {
   background: #FFFFCC;
-  border: double thick red;
+  border: double thick #D50606;
 }
 
 figure.diagrams { border: thin solid black; background: white; padding: 1em; }

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -277,14 +277,14 @@ dl.domintro dd p:last-child {
 }
 
 .warning {
-  color: red;
+  color: #CE3C05;
   background: #FFFFCA;
   font-weight: bolder;
   font-style: italic;
 }
 .warning::before {
   color: yellow;
-  background: red;
+  background: #CE3C05;
 }
 .warning em, .warning i, .warning var, .warning cite {
   font-style: normal;

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -49,8 +49,8 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; background: 
 }
 
 code { color: #666666; font-style: normal; }
-dfn code { color: #ce3c05; }
-code :link, :link code, code :visited, :visited code { color: #ce3c05; }
+dfn code { color: #CE3C05; }
+code :link, :link code, code :visited, :visited code { color: #CE3C05; }
 pre :link, pre :visited { color: inherit; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }

--- a/whatwg.org/style/specification
+++ b/whatwg.org/style/specification
@@ -15,8 +15,8 @@ body { margin: 0 auto; padding: 0 1.5em 2em 2.5em; max-width: 80em; background: 
   pre:hover :link, pre:hover :visited { text-decoration: underline; }
 }
 code { color: #666666; }
-dfn code { color: #CE3C05; }
-code :link, :link code, code :visited, :visited code { color: #CE3C05; }
+dfn code { color: orangered; }
+code :link, :link code, code :visited, :visited code { color: orangered; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h1, h2, h3, h4, h5, h6 { text-align: left; text-rendering: optimizeLegibility; text-shadow: white 0 0 2px; }

--- a/whatwg.org/style/specification
+++ b/whatwg.org/style/specification
@@ -15,8 +15,8 @@ body { margin: 0 auto; padding: 0 1.5em 2em 2.5em; max-width: 80em; background: 
   pre:hover :link, pre:hover :visited { text-decoration: underline; }
 }
 code { color: #666666; }
-dfn code { color: orangered; }
-code :link, :link code, code :visited, :visited code { color: orangered; }
+dfn code { color: #ce3c05; }
+code :link, :link code, code :visited, :visited code { color: #ce3c05; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h1, h2, h3, h4, h5, h6 { text-align: left; text-rendering: optimizeLegibility; text-shadow: white 0 0 2px; }

--- a/whatwg.org/style/specification
+++ b/whatwg.org/style/specification
@@ -15,8 +15,8 @@ body { margin: 0 auto; padding: 0 1.5em 2em 2.5em; max-width: 80em; background: 
   pre:hover :link, pre:hover :visited { text-decoration: underline; }
 }
 code { color: #666666; }
-dfn code { color: #ce3c05; }
-code :link, :link code, code :visited, :visited code { color: #ce3c05; }
+dfn code { color: #CE3C05; }
+code :link, :link code, code :visited, :visited code { color: #CE3C05; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h1, h2, h3, h4, h5, h6 { text-align: left; text-rendering: optimizeLegibility; text-shadow: white 0 0 2px; }

--- a/whatwg.org/style/subpages.css
+++ b/whatwg.org/style/subpages.css
@@ -86,8 +86,8 @@ dl.compact > div > dd:not(:last-of-type)::after { content: "; "; }
 .note em, .note i, .note var { font-style: normal; }
 span.note { padding: 0 2em; }
 .note::before { content: 'Note'; background: green; color: white; padding: 0.15em 0.25em; font-style: normal; position: absolute; top: -0.2em; left: -1.5em; transform: rotate(-5deg); }
-.example { display: block; color: #222222; background: #EEEEEE; margin-left: 2em; padding-left: 3em; position: relative; }
-.example::before { font-style: normal; content: 'Example'; background: #222222; color: #EEEEEE; padding: 0.15em 0.25em; font: 1em Helvetica Neue, sans-serif, Droid Sans Fallback; position: absolute; top: 0.2em; left: -2.25em; transform: rotate(-5deg); }
+.example { display: block; color: #222222; background: #F7F7F7; margin-left: 2em; padding-left: 3em; position: relative; }
+.example::before { font-style: normal; content: 'Example'; background: #222222; color: #F7F7F7; padding: 0.15em 0.25em; font: 1em Helvetica Neue, sans-serif, Droid Sans Fallback; position: absolute; top: 0.2em; left: -2.25em; transform: rotate(-5deg); }
 
 /* SELF LINK STYLES; they assume only inside headings, on this site */
 a.self-link {


### PR DESCRIPTION
Building on this [PR for the dev edition](https://github.com/whatwg/html/pull/7702), this PR updates some colours in the regular spec layout to help meet WCAG.

I have tried to find all instances of these colours in the repo to try and update them all (except for the mailing list entries and temporary files). 

This updates colour contrast of: 

* `orangered` on white, changing to #d5430c (sorry, I could not find named colour), improving contrast from `3.44 : 1` to `4.91 : 1`
* gray backgrounds in notes and MDN annotation from #EEE to #f5f5f5, consistent with [update in dev edition](https://github.com/whatwg/html/pull/7702), bumping contrast from `4.19 : 1` to `4.54 : 1` / `4.8 : 1` (MDN annotation)

<img width="352" alt="comparing mdn badge, the one on the right has a lighter gray background" src="https://user-images.githubusercontent.com/178782/158367769-d85f7c0c-b32a-4848-bcf3-f8b72eefc651.png">
<img width="1503" alt="comparing code examples, the one on the right has a lighter gray background" src="https://user-images.githubusercontent.com/178782/158367821-5852efcf-2d71-4c9d-b481-d6a1bb696321.png">
<img width="1188" alt="comparing lists of properties, the one on the right uses less bright orange in linked property names" src="https://user-images.githubusercontent.com/178782/158367846-f4733608-0393-49aa-9c5e-d3ef8e4deee5.png">

