### PR TITLE
Meta: bump some build.yml numbers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
       with:
-        python-version: 3.8
-    - uses: actions/setup-node@v1
+        python-version: "3.10"
+    - uses: actions/setup-node@v3
       with:
-        node-version: 14
+        node-version: 16
     - run: pip install -r requirements.txt
     - run: npm install
     - run: shellcheck deploy.sh


### PR DESCRIPTION
This generally keeps it in sync with whatwg/html, whatwg/spec-factory, and other places.