### PR TITLE
Styling hgroup p

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -54,11 +54,11 @@ code :link, :link code, code :visited, :visited code { color: #CE3C05; }
 pre :link, pre :visited { color: inherit; }
 
 html, ::before { font: 1em/1.45 Helvetica Neue, sans-serif, Droid Sans Fallback; }
-h1, h2, h3, h4, h5, h6 { text-align: left; text-rendering: optimizeLegibility; }
-h1, h2, h3 { color: #3c790a; background: transparent; }
+h1, h2, h3, h4, h5, h6, hgroup p { text-align: left; text-rendering: optimizeLegibility; }
+h1, h2, h3, hgroup p { color: #3c790a; background: transparent; }
 h1 { font: 900 200% Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h1.allcaps { font: 900 350% Helvetica Neue, sans-serif, Droid Sans Fallback; letter-spacing: 2px; }
-h2 { font: 800 140% Helvetica Neue, sans-serif, Droid Sans Fallback; }
+h2, hgroup p { font: 800 140% Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h3 { font: 800 125% Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h4 { font: 800 110% Helvetica Neue, sans-serif, Droid Sans Fallback; }
 h5 { font: 800 100% Helvetica Neue, sans-serif, Droid Sans Fallback; }
@@ -329,7 +329,7 @@ figure.diagrams img { display: block; margin: 1em auto; }
 h2:not(.short) { page-break-before: always; }
 h2#contents { page-break-before: avoid; }
 h1, h2, h3, h4, h5, h6, dt { page-break-after: avoid; }
-hgroup h2, h1 + h2, hr + h2.no-toc { page-break-before: auto ! important; }
+hgroup p, h1 + h2, hr + h2.no-toc { page-break-before: auto ! important; }
 
 .brief { margin-top: 1em; margin-bottom: 1em; line-height: 1.1; }
 .brief > li { margin: 0; padding: 0; }
@@ -370,10 +370,10 @@ td.non-rectangular-cell-indentation { border-top-style: hidden; min-width: 2em; 
 .head { margin: 0 0 1em; padding: 1em 0 0 0; display: block; }
 .head p { margin: 0; }
 .head h1 { margin: 0 100px 0 0; }
-.head h2 { margin-top: 0; margin-right: 100px; }
+hgroup p { margin: 0 100px 1em 0; }
 @media (max-width: 767px) {
   .head .logo img { width: 4em; height: 4em; }
-  .head h1, .head h2 { margin-right:5rem; }
+  .head h1, hgroup p { margin-right:5rem; }
 }
 .head dl { margin: 1em 0; }
 p.copyright { font-size: 0.6em; font-style: oblique; margin: 0; }


### PR DESCRIPTION
Needed for https://github.com/whatwg/whatwg.org/issues/401.

---

@domenic this sorta does the thing, but I haven't tested it and it could certainly be organized better. Though some of this was already a mess with sometimes using `.head` and sometimes `hgroup` (as far as I can tell that comes down to the same thing).

Probably also want to look at the style inspector to make sure there's not a lot of rules getting dropped and such.