### PR TITLE
Meta: bump actions/setup-python

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: "3.10"
     - uses: actions/setup-node@v3
       with:
-        node-version: 16
+        node-version: 18
     - run: pip install -r requirements.txt
     - run: npm install
     - run: shellcheck deploy.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - uses: actions/setup-node@v3


### PR DESCRIPTION
As you can see in this log `@v3` issues a warning: https://github.com/whatwg/whatwg.org/actions/runs/3410148383/jobs/5672752326. Let's see if that warning disappears.