### PR TITLE
bugfix: generate section with id

### DIFF
--- a/convert_sg_db.py
+++ b/convert_sg_db.py
@@ -85,7 +85,7 @@ def create_workstreams(db, template):
     introduction = introduction.replace("<!-- This ends up being included at https://whatwg.org/workstreams -->\n", "")
     content = markdown(introduction, obtain_link_mapping())
     for workstream in db["workstreams"]:
-        content += "\n<h2>{}</h2>".format(workstream["name"])
+        content += '\n<h2 id="{}">{}</h2>'.format(workstream["id"], workstream["name"])
         content += """\n<dl class="compact">"""
         content += "\n <div>"
         content += "\n  <dt>Scope</dt>"


### PR DESCRIPTION
Other pages used hyperlinks to this one with anchors links. We want to fix the following page: https://wicg.github.io/admin/charter.html#liaisons which has links to this page, but it would be easier if the IDs were working, we believe that just inserting this id in the code will help a lot.

Co-authored-by: Guilherme Siquinelli <guiseek@gmail.com>