### PR TITLE
Add a margin to <table>s

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -151,7 +151,7 @@ pre em { font-weight: bolder; font-style: normal; }
 var sub { vertical-align: bottom; font-size: smaller; top: 0.1em; }
 var > var::before { content: "⟨"; font-style: normal; }
 var > var::after { content: "⟩"; font-style: normal; }
-table { border-collapse: collapse; border-style: hidden hidden none hidden; }
+table { border-collapse: collapse; border-style: hidden hidden none hidden; margin: 1.25em 0; }
 table thead, table tbody { border-bottom: solid; }
 table tbody th { text-align: left; }
 table tbody th:first-child { border-left: solid; }


### PR DESCRIPTION
Although this is normally not necessary when they are adjacent to `<p>`s, sometimes they are adjacent to each other, in which case this is needed.

Showed up in https://github.com/whatwg/html/pull/8502.