### PR TITLE
Recommend loading commit-snapshot-shortcut-key.js with defer as it installs a DOMContentLoaded listener

### DIFF
--- a/resources.whatwg.org/commit-snapshot-shortcut-key.js
+++ b/resources.whatwg.org/commit-snapshot-shortcut-key.js
@@ -2,7 +2,7 @@
 // `<a href="https://{my-spec}.spec.whatwg.org/commit-snapshots/{commit-sha}" id="commit-snapshot-link">Snapshot as of this commit</a>`.
 //
 // Then include this script with
-// `<script src="https://resources.whatwg.org/commit-snapshot-shortcut-key.js" async></script>`.
+// `<script src="https://resources.whatwg.org/commit-snapshot-shortcut-key.js" defer></script>`.
 
 (function () {
   'use strict';


### PR DESCRIPTION
Fixing what I believe is a little bug in the `commit-snapshot-shortcut-key.js` script. In `html.spec.whatwg.org` it's loaded with the `async` flag, which means it can run after the `DOMContentLoaded` event has fired. The listener that sets up the keyboard shortcut will never run in that case. Only a script with `defer` is guaranteed to run before `DOMContentLoaded`.

The fix uses the `load` event instead, which is fired only after even the `async` scripts are finished running.

In the spec, [this is the place](https://html.spec.whatwg.org/#the-end:set-of-scripts-that-will-execute-as-soon-as-possible) where all the `async` scripts are flushed, and it runs between the `DOMContentLoaded` and `load` events.

I found this when trying to learn what exactly the difference between `async` and `defer` is.