### PR TITLE
Make focus visible on the logo element at the top of the page

### DIFF
--- a/resources.whatwg.org/spec.css
+++ b/resources.whatwg.org/spec.css
@@ -1,4 +1,5 @@
-.head .logo img { position: absolute; top: 1em; right: 1em; border: none; }
+.head .logo { position: absolute; top: 1em; right: 1em; line-height: 0; }
+.head .logo img { border: none; }
 
 .toc, .toc li { list-style: none; }
 


### PR DESCRIPTION
On all spec pages, their logo doesn't have focus around the element.
This fails [WCAG 2.4.7 Focus Visible](https://www.w3.org/TR/WCAG21/#focus-visible)