### PR TITLE
Avoid generating review drafts for merge commits

### DIFF
--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -122,7 +122,7 @@ echo ""
 
 header "Starting review drafts (if applicable)..."
 echo "Note: review drafts must be added or changed in a single commit on main"
-CHANGED_FILES=$(git diff --name-only HEAD^ HEAD)
+CHANGED_FILES=$(git show --format="format:" --name-only HEAD)
 for CHANGED in $CHANGED_FILES; do # Omit quotes around variable to split on whitespace
     if ! [[ "$CHANGED" =~ ^review-drafts/.*.bs$ ]]; then
         continue


### PR DESCRIPTION
This avoids generating review drafts for merge commits unless the merge  commit has modifications to the review draft (which I hope means that it's different from all parents of the merge).

The code prior to this change tries to generate a review draft if the  first parent of the merge commit introduces a review draft. (This happens if "git merge main" is done on a feature branch and main has introduced a review draft.)

This matches the change in 
https://github.com/whatwg/html-build/pull/284 .