### PR TITLE
Darkmode the remaining colors used in a few HTML spots.

### DIFF
--- a/resources.whatwg.org/standard-service-worker.js
+++ b/resources.whatwg.org/standard-service-worker.js
@@ -8,7 +8,7 @@
 
 const standardShortname = location.host.split(".")[0];
 
-const cacheKey = "v10";
+const cacheKey = "v11";
 const toCache = [
   location.origin + "/",
   "https://resources.whatwg.org/spec.css",

--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -28,6 +28,13 @@ html {
 
   --heading-text: var(--whatwg-green);
 
+  --element-text: var(--text);
+  --element-bg: #eeffee;
+
+  --navblock-text: var(--text);
+  --navblock-a-text: var(--a-normal-text);
+  --navblock-mask-bg: rgba(255,255,255,0.9);
+
   --note-text: green;
   --note-bg: #dfd;
   --note-heading-text: var(--bg);
@@ -90,6 +97,9 @@ html {
   --mdn-nosupport-text: #ccc;
   --mdn-pass: green;
   --mdn-fail: red;
+
+  --raretr-text: #333;
+  --raretr-bg: #f7f7f7;
 }
 @media (prefers-color-scheme: dark) {
   :root {
@@ -108,6 +118,13 @@ html {
     --code-special-text: #ff7b54;
 
     --heading-text: var(--whatwg-green);
+
+    --element-text: var(--text);
+    --element-bg: #000800;
+
+    --navblock-text: var(--text);
+    --navblock-a-text: var(--a-normal-text);
+    --navblock-mask-bg: rgba(0,0,0,0.9);
 
     --note-text: #8f8;
     --note-bg: #020;
@@ -171,6 +188,9 @@ html {
     --mdn-nosupport-text: #666;
     --mdn-pass: #690;
     --mdn-fail: #d22;
+
+    --raretr-text: #bbb;
+    --raretr-bg: #040404;
   }
 }
 

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -26,7 +26,8 @@ body { margin: 0 auto; padding: 0 2.5em 2em 2.5em; max-width: 80em; }
   position: fixed;
   bottom: 0;
   right: 0;
-  background: rgba(255, 255, 255, 0.8);
+  /* color works on either white or black text */
+  background: rgba(127, 127, 127, .5);
   font-size: smaller;
   padding: 4px 10px;
   z-index: 4;
@@ -137,7 +138,7 @@ dl.props > dt { grid-column-start: 1; margin: 0; }
 dl.props > dd { grid-column-start: 2; margin: 0; }
 p + dl.props { margin-top: -0.5em; }
 
-tr.rare { background: #F7F7F7; color: #333333; }
+tr.rare { background: var(--raretr-bg); color: var(--raretr-text); }
 
 /*
  * .domintro, .note, .warning, .example, .XXX, .critical
@@ -176,7 +177,6 @@ li > .domintro, li > .note, li > .warning, li > .example {
   position: absolute;
   top: -0.8em;
   left: -0.8em;
-  color: white;
 }
 @media (max-width: 767px) {
   .domintro, .note, .warning, .example {
@@ -247,7 +247,7 @@ span.note::before, span.warning::before {
   font-style: italic;
 }
 .note::before {
-  color:  var(--note-heading-text);
+  color: var(--note-heading-text);
   background: var(--note-heading-bg);
 }
 .note em, .note i, .note var, .note cite {
@@ -299,6 +299,8 @@ td > .example:only-child::before {
   border: double thick var(--critical-border);
 }
 
+/* Diagrams generally have white backgrounds,
+   so keeping this color white in darkmode is necessary. */
 figure.diagrams { border: thin solid black; background: white; padding: 1em; }
 figure.diagrams img { display: block; margin: 1em auto; }
 
@@ -332,7 +334,7 @@ hgroup p, h1 + h2, hr + h2.no-toc { page-break-before: auto ! important; }
 
 h4 { position: relative; z-index: 3; }
 h4 + .element, h4 + div.status + .element { margin-top: -2.75em; padding-top: 1.5em; }
-.element { background: #EEFFEE; color: black; margin: 0 0 1em -0.15em; padding: 0 1em 0.25em 1em; }
+.element { background: var(--element-bg); color: var(--element-text); margin: 0 0 1em -0.15em; padding: 0 1em 0.25em 1em; }
 .element:not(:hover) > dt > :link, .element:not(:hover) > dt > :visited { color: inherit; text-decoration: none; }
 
 table.css-property caption { text-align: left; font: inherit; font-weight: bolder; }
@@ -371,7 +373,7 @@ header + nav { margin: 1em 0; }
   text-decoration: none;
   width: auto;
   margin: 0.5em;
-  color: #F3F3F3;
+  color: var(--navblock-text);
   text-align: center;
 }
 @keyframes stand-out {
@@ -386,8 +388,8 @@ html:not(.split) #multipage-link { animation: 10s ease 0s 1 stand-out; }
 #head nav > div > a > * > * {
   display: block;
   padding: 0.1em 1em 0.1em;
-  background: rgba(255,255,255,0.9);
-  color: black;
+  background: var(--navblock-mask-bg);
+  color: var(--navblock-text);
   font: inherit;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -399,7 +401,7 @@ html:not(.split) #multipage-link { animation: 10s ease 0s 1 stand-out; }
   padding-bottom: 1em;
 }
 #head nav > div > a > * > strong {
-  color: blue;
+  color: var(--navblock-a-text);
   text-decoration: underline;
   padding-bottom: 0.5em;
 }
@@ -483,7 +485,6 @@ pre.idl,
 pre > code.css,
 pre.highlight.lang-css {
   border: solid 0.0625em;
-  color: black;
   border-top-left-radius: 0;
 }
 


### PR DESCRIPTION
Sorry, missed several specialized bits on the first pass, because I was just looking at DOM/etc, not HTML. Every single `color`, `background`, and `border` declaration in `standard.css` has been double-checked now.

* The `box-shadow` colors on the first-page nav blocks in HTML are kept as-is rather than being abstracted; once I swapped out the transparent overlay from nearly-white to nearly-black, the specified colors ended up still looking great, imo.
* I think that the "file a bug from selected text" functionality was removed, so possibly we can just kill that style.
* I also couldn't find any `tr.rare` elements, so I had to just guess at a reasonable color swap. I verified they looked reasonable on some random text, but I'm not sure if there's some particulars in context that would make it weird. Probably not, tho.