### PR TITLE
Defensively guard against non-darkmode-aware SVGs by giving them a white background.

### DIFF
--- a/resources.whatwg.org/standard-shared-with-dev.css
+++ b/resources.whatwg.org/standard-shared-with-dev.css
@@ -629,3 +629,13 @@ ul.domTree li:not(:last-child)::after {
   content: '';
   border-width: 0.1em;
 }
+
+/* Just in case, SVGs that aren't explicitly
+   marked as darkmode-aware get a white background,
+   as they might have a transparent background
+   and are assuming they're rendered against white.
+*/
+:is(img, iframe)[src$=".svg"]:not(.darkmode-aware),
+svg:not(.darkmode-aware) {
+  background: white;
+}


### PR DESCRIPTION
SVGs are usually authored with a transparent background, and usually assume they're displayed against a light background, using black text/etc. This often renders them unreadable in darkmode.

To guard against this, this PR automatically gives them a white background, unless they have a `.darkmode-aware` class.

See also <https://github.com/whatwg/html/pull/10257>, where I'm fixing all of HTML's SVG's to be darkmode-aware. These PRs can be merged in either order; both "fix" the problem, this one just does it in a slightly less good (but more generic) way. I'll probably review the other WHATWG specs for SVG diagrams that need to be flagged as well, but later.