### PR TITLE
Support dark mode in tracking-vector.svg

### DIFF
--- a/resources.whatwg.org/tracking-vector.svg
+++ b/resources.whatwg.org/tracking-vector.svg
@@ -1,3 +1,3 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46 64" stroke="black" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3,2,35,2,20,2" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46 64" style="color-scheme: light dark;" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-dasharray="3,2,35,2,20,2" fill="none">
 <path d="M2 23Q17 -16 40 12M1 35Q17 -20 43 20M2 40Q18 -19 44 25M3 43Q19 -16 45 29M5 46Q20 -12 45 32M5 49Q11 40 15 27T27 16T45 37M5 49Q15 38 19 25T34 27T44 41M6 52Q17 40 21 28T32 29T43 44M6 52Q21 42 23 31T30 32T42 47M7 54Q23 47 24 36T28 34T41 50M8 56Q26 50 26 35Q28 48 40 53M10 58Q24 54 27 45Q30 52 38 55M27 50Q28 53 36 57M25 52Q28 56 31 57M22 55L26 57M10 58L37 57M13 60L32 60M16 62L28 63"/>
 </svg>


### PR DESCRIPTION
See https://github.com/w3c/tr-design/issues/162#issuecomment-2122073793

Demo: https://software.hixie.ch/utilities/js/live-dom-viewer/saved/12744

This seems to work in Gecko and Chromium, but not WebKit.