### PR TITLE
Specifically list `e.g.,` and `i.e.,` in the grammar section

### DIFF
--- a/whatwg.org/style-guide
+++ b/whatwg.org/style-guide
@@ -57,6 +57,8 @@
  <li>scrollbar</li>
  <li>style sheet</li>
  <li>whitespace (though CSS '<code>white-space</code>' [sic] property)</li>
+ <li>e.g.,</li>
+ <li>i.e.,</li>
 </ul>
 
 <h2 id="grammar">Grammar<a class="self-link" href="#grammar"></a></h2>

--- a/whatwg.org/style-guide
+++ b/whatwg.org/style-guide
@@ -66,7 +66,7 @@
  <li>Use the <a href="https://en.wikipedia.org/wiki/Serial_comma">Oxford Comma</a>.</li>
  <li>Avoid "one of" unless it's followed by a bulleted list. You can normally leave it out and just use "or". If you cannot leave it out, that might be a good indication you want to use a bulleted list for clarity.</li>
  <li>"A hierarchy" (not "an").</li>
- <li>Use e.g., and i.e., instead of e.g. and i.e.</li>
+ <li>Use e.g., and i.e., instead of their non-comma-ending variants.</li>
 </ul>
 
 <h2 id="casing">Casing<a class="self-link" href="#casing"></a></h2>

--- a/whatwg.org/style-guide
+++ b/whatwg.org/style-guide
@@ -57,8 +57,6 @@
  <li>scrollbar</li>
  <li>style sheet</li>
  <li>whitespace (though CSS '<code>white-space</code>' [sic] property)</li>
- <li>e.g.,</li>
- <li>i.e.,</li>
 </ul>
 
 <h2 id="grammar">Grammar<a class="self-link" href="#grammar"></a></h2>
@@ -68,6 +66,7 @@
  <li>Use the <a href="https://en.wikipedia.org/wiki/Serial_comma">Oxford Comma</a>.</li>
  <li>Avoid "one of" unless it's followed by a bulleted list. You can normally leave it out and just use "or". If you cannot leave it out, that might be a good indication you want to use a bulleted list for clarity.</li>
  <li>"A hierarchy" (not "an").</li>
+ <li>Use e.g., and i.e., instead of e.g. and i.e.</li>
 </ul>
 
 <h2 id="casing">Casing<a class="self-link" href="#casing"></a></h2>


### PR DESCRIPTION
See:
 - https://english.stackexchange.com/a/241108/157224: for American english preferring `e.g.,`
 - For preferring `i.e.,` over `i.e.`, that is just a matter of preference. The HTML Standard has 81 occurrences of `i.e., ` compared to 49 instances of `i.e. `
 - https://github.com/whatwg/html/pull/10392#discussion_r1626822741
 - https://github.com/whatwg/html/pull/10392#discussion_r1626825552