### PR TITLE
Fix vnu download link in deploy scripts

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -50,7 +50,7 @@ if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     readarray -d '' TARGETS < <(find whatwg.org -maxdepth 1 -type f ! -name "*.*" ! -name "status-2008-12" -print0)
     TARGETS+=(whatwg.org/news whatwg.org/validator whatwg.org/index.html idea.whatwg.org/index.html spec.whatwg.org/index.html)
 
-    curl --retry 2 --fail --remote-name --location https://github.com/validator/validator/releases/download/latest/vnu.linux.zip
+    curl --retry 2 --fail --remote-name --location https://github.com/validator/validator/releases/latest/download/vnu.linux.zip
     unzip -qq vnu.linux.zip
     # shellcheck disable=SC1111
     FILTER_PATTERN=".*Illegal character in fragment: “#” is not allowed.*"

--- a/resources.whatwg.org/build/deploy.sh
+++ b/resources.whatwg.org/build/deploy.sh
@@ -155,7 +155,7 @@ echo ""
 # Run the HTML checker only in CI
 if [[ "$GITHUB_ACTIONS" == "true" ]]; then
     header "Running the HTML checker..."
-    curlretry --fail --remote-name --location https://github.com/validator/validator/releases/download/latest/vnu.linux.zip
+    curlretry --fail --remote-name --location https://github.com/validator/validator/releases/latest/download/vnu.linux.zip
     unzip -q vnu.linux.zip
     if [ -f .htmlcheckerfilter ]; then
       ./vnu-runtime-image/bin/vnu --verbose --skip-non-html --Werror --filterfile .htmlcheckerfilter "$WEB_ROOT"


### PR DESCRIPTION
According to [the GitHub docs](https://docs.github.com/en/repositories/releasing-projects-on-github/linking-to-releases#linking-to-the-latest-release), the download link should be `/releases/latest/download/` but we were using `/releases/download/latest/`. The old URL now returns HTTP 404 and [breaks our deploy script](https://github.com/whatwg/compression/pull/79#issuecomment-3490281004).