### PR TITLE
Remove the animation for the multipage link

### DIFF
--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -379,7 +379,7 @@ header + nav { margin: 1em 0; }
   color: var(--navblock-text);
   text-align: center;
 }
-html:not(.split) #multipage-link { box-shadow: 0 0 0 2px #3C790A; }
+html:not(.split) #multipage-link { box-shadow: 0 0 0 2px #3C790A; border-radius: 1px; }
 #head nav > div > a { box-shadow: 0 0 2px #3C790A; background: #3C790A; }
 #head nav > div > a.comms { box-shadow: 0 0 2px #165FCC; background: #165FCC; } /* #165FCC #43679D #0B2F66 */
 #head nav > div > a.feedback { box-shadow: 0 0 2px #FF3E3A; background: #FF3E3A; } /* #FF3E3A #CD6B6A #990300 */

--- a/resources.whatwg.org/standard.css
+++ b/resources.whatwg.org/standard.css
@@ -379,10 +379,7 @@ header + nav { margin: 1em 0; }
   color: var(--navblock-text);
   text-align: center;
 }
-@keyframes stand-out {
-  0%, 95% { transform: scale(1.4); box-shadow: 0 2px 10px gray; }
-}
-html:not(.split) #multipage-link { animation: 10s ease 0s 1 stand-out; }
+html:not(.split) #multipage-link { box-shadow: 0 0 0 2px #3C790A; }
 #head nav > div > a { box-shadow: 0 0 2px #3C790A; background: #3C790A; }
 #head nav > div > a.comms { box-shadow: 0 0 2px #165FCC; background: #165FCC; } /* #165FCC #43679D #0B2F66 */
 #head nav > div > a.feedback { box-shadow: 0 0 2px #FF3E3A; background: #FF3E3A; } /* #FF3E3A #CD6B6A #990300 */
@@ -544,7 +541,7 @@ For darkmode:
 2 = oklab(50% -64%  -20%)
 3 = oklab(50%   6%   19%)
 4 = oklab(50% -12%  -64%)
-5 = oklab(50%  44%  -19%)  
+5 = oklab(50%  44%  -19%)
 6 = oklab(50% 102%   38%)
 */
 


### PR DESCRIPTION
Instead have a persistent and more prominent box-shadow.

Part of https://github.com/whatwg/html/issues/12782

Preview:
<img width="906" height="341" alt="The multipage link has a green outline." src="https://github.com/user-attachments/assets/e5c4e031-31ec-4f85-9a0c-d029bf32e473" />
